### PR TITLE
Use 'inference' instead of 'prediction'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ tox
 from allora_sdk.v2.api_client import (
     AlloraAPIClient,
     ChainSlug,
-    PricePredictionToken,
-    PricePredictionTimeframe,
+    PriceInferenceToken,
+    PriceInferenceTimeframe,
     AlloraTopic,
     AlloraInference,
 )
@@ -72,7 +72,7 @@ result = await client.get_inference_by_topic_id(topics[0].topic_id)
 print(f'{topics[0].topic_name} price inference: {result.inference_data.network_inference_normalized}')
 
 # Fetch inferences by asset and timeframe
-result = await client.get_price_prediction(PricePredictionToken.BTC, PricePredictionTimeframe.EIGHT_HOURS)
+result = await client.get_price_inference(PriceInferenceToken.BTC, PriceInferenceTimeframe.EIGHT_HOURS)
 print(f'{topics[0].topic_name} price inference: {result.inference_data.network_inference_normalized}')
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allora_sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
     "aiohttp",
     "annotated-types==0.7.0",

--- a/src/allora_sdk/v2/api_client.py
+++ b/src/allora_sdk/v2/api_client.py
@@ -14,12 +14,12 @@ class ChainID(str, Enum):
     MAINNET = "allora-mainnet-1"
 
 
-class PricePredictionToken(str, Enum):
+class PriceInferenceToken(str, Enum):
     BTC = "BTC"
     ETH = "ETH"
 
 
-class PricePredictionTimeframe(str, Enum):
+class PriceInferenceTimeframe(str, Enum):
     FIVE_MIN = "5m"
     EIGHT_HOURS = "8h"
 
@@ -140,20 +140,20 @@ class AlloraAPIClient:
         )
 
         if not response.data.inference_data:
-            raise ValueError("Failed to fetch price prediction")
+            raise ValueError("Failed to fetch price inference")
         return response.data
 
-    async def get_price_prediction(
+    async def get_price_inference(
         self,
-        asset: PricePredictionToken,
-        timeframe: PricePredictionTimeframe,
+        asset: PriceInferenceToken,
+        timeframe: PriceInferenceTimeframe,
         signature_format: SignatureFormat = SignatureFormat.ETHEREUM_SEPOLIA,
     ) -> AlloraInference:
         """
-        Fetches a price prediction for a specific asset and timeframe from the Allora API.
+        Fetches a price inference for a specific asset and timeframe from the Allora API.
 
-        :param asset: The asset to get price prediction for
-        :param timeframe: The timeframe to get price prediction for
+        :param asset: The asset to get price inference for
+        :param timeframe: The timeframe to get price inference for
         :param signature_format: The signature format to use
         :return: The inference data
         :raises: requests.RequestException if the API request fails
@@ -164,7 +164,7 @@ class AlloraAPIClient:
         )
 
         if not response.data.inference_data:
-            raise ValueError("Failed to fetch price prediction")
+            raise ValueError("Failed to fetch price inference")
         return response.data
 
     def get_request_url(self, endpoint: str) -> str:

--- a/tests/test_api_client_integration.py
+++ b/tests/test_api_client_integration.py
@@ -3,8 +3,8 @@ import pytest_asyncio
 from allora_sdk.v2.api_client import (
     AlloraAPIClient,
     ChainSlug,
-    PricePredictionToken,
-    PricePredictionTimeframe,
+    PriceInferenceToken,
+    PriceInferenceTimeframe,
     AlloraTopic,
     AlloraInference,
 )
@@ -63,17 +63,17 @@ async def test_get_inference_by_topic_id(client):
     assert len(data.confidence_interval_percentiles) == len(data.confidence_interval_values)
 
 @pytest.mark.asyncio
-async def test_get_price_prediction(client):
-    prediction = await client.get_price_prediction(
-        PricePredictionToken.BTC,
-        PricePredictionTimeframe.EIGHT_HOURS
+async def test_get_price_inference(client):
+    inference = await client.get_price_inference(
+        PriceInferenceToken.BTC,
+        PriceInferenceTimeframe.EIGHT_HOURS
     )
 
-    assert isinstance(prediction, AlloraInference)
-    assert isinstance(prediction.signature, str)
-    assert prediction.signature, "Signature should not be empty"
+    assert isinstance(inference, AlloraInference)
+    assert isinstance(inference.signature, str)
+    assert inference.signature, "Signature should not be empty"
 
-    data = prediction.inference_data
+    data = inference.inference_data
     assert isinstance(data.network_inference, str)
     assert isinstance(data.network_inference_normalized, str)
     assert isinstance(data.topic_id, str)
@@ -89,11 +89,11 @@ async def test_get_price_prediction(client):
     assert len(data.confidence_interval_percentiles) == len(data.confidence_interval_values)
 
 @pytest.mark.asyncio
-async def test_get_price_prediction_different_assets(client):
-    for token in [PricePredictionToken.BTC, PricePredictionToken.ETH]:
-        for timeframe in [PricePredictionTimeframe.FIVE_MIN, PricePredictionTimeframe.EIGHT_HOURS]:
-            prediction = await client.get_price_prediction(token, timeframe)
-            assert isinstance(prediction, AlloraInference)
-            assert prediction.inference_data.network_inference.isdigit()
-            assert float(prediction.inference_data.network_inference_normalized) > 0
+async def test_get_price_inference_different_assets(client):
+    for token in [PriceInferenceToken.BTC, PriceInferenceToken.ETH]:
+        for timeframe in [PriceInferenceTimeframe.FIVE_MIN, PriceInferenceTimeframe.EIGHT_HOURS]:
+            inference = await client.get_price_inference(token, timeframe)
+            assert isinstance(inference, AlloraInference)
+            assert inference.inference_data.network_inference.isdigit()
+            assert float(inference.inference_data.network_inference_normalized) > 0
 

--- a/tests/test_api_client_unit.py
+++ b/tests/test_api_client_unit.py
@@ -1,23 +1,14 @@
 import pytest
-import pytest_asyncio
-from typing import Any, Dict
-import json
-from unittest.mock import MagicMock, patch
-from aiohttp import ClientResponse, ClientSession
 
 from allora_sdk.v2.api_client import (
     AlloraAPIClient,
-    ChainSlug,
-    PricePredictionToken,
-    PricePredictionTimeframe,
+    PriceInferenceTimeframe,
+    PriceInferenceToken,
     SignatureFormat,
-    ChainID,
-    Fetcher,
 )
 from .mock_data import (
     MockServer,
     StarletteMockFetcher,
-    mock_topics_response,
     mock_inference,
     mock_api_response,
     mock_topic_1,
@@ -67,22 +58,22 @@ async def test_get_inference_by_topic_id():
     assert inference.inference_data.network_inference_normalized == mock_inference["inference_data"]["network_inference_normalized"]
 
 @pytest.mark.asyncio
-async def test_get_price_prediction():
+async def test_get_price_inference():
     server.add_mock_response(mock_api_response, 200)
     client = AlloraAPIClient(fetcher=fetcher)
-    prediction = await client.get_price_prediction(PricePredictionToken.BTC, PricePredictionTimeframe.FIVE_MIN)
+    inference = await client.get_price_inference(PriceInferenceToken.BTC, PriceInferenceTimeframe.FIVE_MIN)
 
-    assert prediction.inference_data.network_inference == mock_inference["inference_data"]["network_inference"]
-    assert prediction.inference_data.network_inference_normalized == mock_inference["inference_data"]["network_inference_normalized"]
+    assert inference.inference_data.network_inference == mock_inference["inference_data"]["network_inference"]
+    assert inference.inference_data.network_inference_normalized == mock_inference["inference_data"]["network_inference_normalized"]
 
 @pytest.mark.asyncio
-async def test_get_price_prediction_missing_inference_data():
+async def test_get_price_inference_missing_inference_data():
     mock_response = {**mock_api_response, "data": {"signature": "0x1234"}}
     server.add_mock_response(mock_response, 200)
     client = AlloraAPIClient(fetcher=fetcher)
     with pytest.raises(ValueError, match="validation error"):
-        await client.get_price_prediction(
-            PricePredictionToken.BTC,
-            PricePredictionTimeframe.FIVE_MIN,
+        await client.get_price_inference(
+            PriceInferenceToken.BTC,
+            PriceInferenceTimeframe.FIVE_MIN,
         )
 


### PR DESCRIPTION
Main changes added:

- change wording to use "inference" instead of "prediction"
- bump the minor version of the package. New package version: `0.2.0`