### PR TITLE
feat: Add Signer Protocol for flexible credential management

### DIFF
--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,5 +1,14 @@
 from .worker import AlloraWorker
-from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, TxManager, FeeTier
+from .rpc_client import (
+    AlloraRPCClient,
+    AlloraNetworkConfig,
+    AlloraWalletConfig,
+    TxManager,
+    FeeTier,
+    Signer,
+    LocalWalletSigner,
+    VaultSigner,
+)
 from .api_client import AlloraAPIClient
 from .logging_config import setup_sdk_logging
 from cosmpy.aerial.wallet import LocalWallet, PrivateKey
@@ -9,9 +18,14 @@ __all__ = [
     "AlloraRPCClient",
     "AlloraAPIClient",
     "AlloraNetworkConfig",
+    "AlloraWalletConfig",
     "FeeTier",
     "TxManager",
     "setup_sdk_logging",
     "LocalWallet",
     "PrivateKey",
+    # Signer Protocol
+    "Signer",
+    "LocalWalletSigner",
+    "VaultSigner",
 ]

--- a/src/allora_sdk/rpc_client/__init__.py
+++ b/src/allora_sdk/rpc_client/__init__.py
@@ -1,11 +1,16 @@
 from .client import AlloraRPCClient
-from .config import AlloraNetworkConfig
+from .config import AlloraNetworkConfig, AlloraWalletConfig
 from .tx_manager import FeeTier, TxManager
+from .signer import Signer, LocalWalletSigner, VaultSigner
 
 
 __all__ = [
     "AlloraRPCClient",
     "AlloraNetworkConfig",
+    "AlloraWalletConfig",
     "TxManager",
     "FeeTier",
+    "Signer",
+    "LocalWalletSigner",
+    "VaultSigner",
 ]

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -1,8 +1,11 @@
 import os
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, TYPE_CHECKING
 from cosmpy.aerial.config import NetworkConfig
 from cosmpy.aerial.wallet import LocalWallet
+
+if TYPE_CHECKING:
+    from .signer import Signer
 
 
 @dataclass
@@ -15,8 +18,21 @@ class AlloraWalletConfig:
     - mnemonic: Mnemonic phrase string.
     - mnemonic_file: Path to a file containing the mnemonic phrase.
     - wallet: An existing LocalWallet instance.
+    - signer: A custom Signer implementation (for advanced use cases like VaultSigner).
 
     The address prefix can also be specified (default is "allo").
+
+    Example usage:
+        # Using private key
+        config = AlloraWalletConfig(private_key="deadbeef...")
+
+        # Using mnemonic
+        config = AlloraWalletConfig(mnemonic="word1 word2 ...")
+
+        # Using custom signer (e.g., VaultSigner for Forge platform)
+        from allora_sdk import VaultSigner
+        signer = VaultSigner(backend_url="...", worker_id="...", auth_token="...")
+        config = AlloraWalletConfig(signer=signer)
     """
     private_key: Optional[str] = None
     mnemonic: Optional[str] = None
@@ -24,8 +40,19 @@ class AlloraWalletConfig:
     wallet: Optional[LocalWallet] = None
     prefix: str = "allo"
 
+    # Custom signer for advanced use cases (e.g., VaultSigner for Forge platform)
+    signer: Optional["Signer"] = field(default=None, repr=False)
+
     @classmethod
     def from_env(cls) -> 'AlloraWalletConfig':
+        """Create config from environment variables.
+
+        Supported environment variables:
+        - PRIVATE_KEY: Hex-encoded private key
+        - MNEMONIC: BIP39 mnemonic phrase
+        - MNEMONIC_FILE: Path to file containing mnemonic
+        - ADDRESS_PREFIX: Bech32 prefix (default: "allo")
+        """
         return cls(
             private_key=os.getenv("PRIVATE_KEY"),
             mnemonic=os.getenv("MNEMONIC"),
@@ -38,9 +65,46 @@ class AlloraWalletConfig:
             self.private_key is None and
             self.mnemonic is None and
             self.mnemonic_file is None and
-            self.wallet is None
+            self.wallet is None and
+            self.signer is None
         ):
             raise ValueError("No wallet credentials provided")
+
+    def get_signer(self) -> "Signer":
+        """Get a Signer from the configured credential source.
+
+        Priority: custom signer > wallet > private_key > mnemonic > mnemonic_file
+
+        Returns:
+            Signer instance for signing operations
+
+        Raises:
+            ValueError: If no valid credentials are configured
+        """
+        from .signer import LocalWalletSigner
+
+        # Custom signer takes precedence
+        if self.signer is not None:
+            return self.signer
+
+        # Existing LocalWallet instance
+        if self.wallet is not None:
+            return LocalWalletSigner(wallet=self.wallet, prefix=self.prefix)
+
+        # Private key
+        if self.private_key is not None:
+            return LocalWalletSigner(private_key=self.private_key, prefix=self.prefix)
+
+        # Mnemonic (direct or from file)
+        mnemonic = self.mnemonic
+        if mnemonic is None and self.mnemonic_file is not None:
+            with open(self.mnemonic_file, 'r') as f:
+                mnemonic = f.read().strip()
+
+        if mnemonic is not None:
+            return LocalWalletSigner(mnemonic=mnemonic, prefix=self.prefix)
+
+        raise ValueError("No valid credentials configured")
 
 
 @dataclass

--- a/src/allora_sdk/rpc_client/signer.py
+++ b/src/allora_sdk/rpc_client/signer.py
@@ -1,0 +1,276 @@
+"""
+Signer Protocol and implementations for Allora SDK.
+
+This module provides a unified interface for signing operations, supporting:
+- LocalWalletSigner: For local credential management (private_key, mnemonic, wallet)
+- VaultSigner: For platform-hosted deployments (Forge) with remote signing
+
+Usage:
+    # Local signing with private key
+    signer = LocalWalletSigner(private_key="deadbeef...")
+    signature = signer.sign_digest(digest_bytes)
+
+    # Local signing with mnemonic
+    signer = LocalWalletSigner(mnemonic="word1 word2 ...")
+
+    # Remote signing (Forge platform)
+    signer = VaultSigner(
+        backend_url="http://backend:8080",
+        worker_id="uuid",
+        auth_token="bootstrap_token"
+    )
+"""
+
+from typing import Protocol, runtime_checkable, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class Signer(Protocol):
+    """Abstract interface for signing operations.
+
+    Enables different credential sources to provide a unified signing interface.
+    Compatible with existing LocalWallet-based workflows.
+
+    Implementations:
+        - LocalWalletSigner: Wraps cosmpy LocalWallet for local signing
+        - VaultSigner: Delegates signing to backend for platform-hosted keys
+    """
+
+    def sign_digest(self, digest: bytes) -> bytes:
+        """Sign a SHA256 digest and return the signature.
+
+        Args:
+            digest: 32-byte SHA256 digest to sign
+
+        Returns:
+            Signature bytes (typically 64 bytes for secp256k1)
+        """
+        ...
+
+    @property
+    def public_key_hex(self) -> str:
+        """Get hex-encoded compressed public key."""
+        ...
+
+    @property
+    def address(self) -> str:
+        """Get bech32 wallet address."""
+        ...
+
+
+class LocalWalletSigner:
+    """Signer wrapping cosmpy LocalWallet.
+
+    Supports all existing credential options:
+    - private_key: Hex-encoded 32-byte private key
+    - mnemonic: BIP39 24-word seed phrase
+    - wallet: Pre-initialized LocalWallet instance
+
+    This is the default signer for self-hosted deployments where users
+    manage their own credentials.
+
+    Example:
+        # From private key
+        signer = LocalWalletSigner(private_key="deadbeef...")
+
+        # From mnemonic
+        signer = LocalWalletSigner(mnemonic="word1 word2 word3 ...")
+
+        # From existing wallet
+        signer = LocalWalletSigner(wallet=my_wallet)
+
+        # Sign a digest
+        signature = signer.sign_digest(digest_bytes)
+    """
+
+    def __init__(
+        self,
+        private_key: Optional[str] = None,
+        mnemonic: Optional[str] = None,
+        wallet: Optional["LocalWallet"] = None,
+        prefix: str = "allo"
+    ):
+        """Initialize signer from credentials.
+
+        Args:
+            private_key: Hex-encoded 32-byte private key
+            mnemonic: BIP39 24-word seed phrase
+            wallet: Pre-initialized LocalWallet instance
+            prefix: Bech32 address prefix (default: "allo")
+
+        Raises:
+            ValueError: If no valid credentials provided
+        """
+        from cosmpy.aerial.wallet import LocalWallet, PrivateKey
+
+        if wallet is not None:
+            self._wallet = wallet
+        elif private_key is not None:
+            pk = PrivateKey(bytes.fromhex(private_key))
+            self._wallet = LocalWallet(pk, prefix=prefix)
+        elif mnemonic is not None:
+            self._wallet = LocalWallet.from_mnemonic(mnemonic, prefix=prefix)
+        else:
+            raise ValueError("Must provide private_key, mnemonic, or wallet")
+
+        self._prefix = prefix
+
+    def sign_digest(self, digest: bytes) -> bytes:
+        """Sign a SHA256 digest using the local wallet.
+
+        Args:
+            digest: 32-byte SHA256 digest to sign
+
+        Returns:
+            64-byte secp256k1 signature
+        """
+        return self._wallet.signer().sign_digest(digest)
+
+    @property
+    def public_key_hex(self) -> str:
+        """Get hex-encoded compressed public key."""
+        return self._wallet.public_key().public_key_hex
+
+    @property
+    def address(self) -> str:
+        """Get bech32 wallet address."""
+        return str(self._wallet.address())
+
+    @property
+    def wallet(self) -> "LocalWallet":
+        """Access underlying LocalWallet for SDK compatibility.
+
+        This allows existing code that expects a LocalWallet to continue working.
+        """
+        return self._wallet
+
+
+class VaultSigner:
+    """Remote signer for platform-hosted deployments.
+
+    Delegates signing to a backend service where keys are securely stored.
+    Used by Forge platform workers where private keys remain in the vault
+    and never leave the secure environment.
+
+    Security benefits:
+    - Private keys never exposed to worker pods
+    - Centralized key management and rotation
+    - Audit logging of all signing operations
+    - Keys protected by vault encryption
+
+    Example:
+        signer = VaultSigner(
+            backend_url="http://backend:8080",
+            worker_id="550e8400-e29b-41d4-a716-446655440000",
+            auth_token="bootstrap_token_here"
+        )
+
+        # Sign a digest (makes HTTP call to backend)
+        signature = signer.sign_digest(digest_bytes)
+    """
+
+    def __init__(self, backend_url: str, worker_id: str, auth_token: str):
+        """Initialize vault signer.
+
+        Args:
+            backend_url: Backend API base URL (e.g., "http://backend:8080")
+            worker_id: Worker UUID for signing requests
+            auth_token: Bootstrap token or auth token for API authentication
+        """
+        self._backend_url = backend_url.rstrip('/')
+        self._worker_id = worker_id
+        self._auth_token = auth_token
+        self._public_key: Optional[str] = None
+        self._address: Optional[str] = None
+
+    def _ensure_identity(self):
+        """Lazy-load identity from backend if not cached.
+
+        Fetches public key and address from the backend API.
+        These are cached after the first call.
+        """
+        if self._public_key is None or self._address is None:
+            import httpx
+
+            logger.debug(f"Fetching identity for worker {self._worker_id}")
+            resp = httpx.get(
+                f"{self._backend_url}/api/v1/workers/{self._worker_id}/identity",
+                headers={"Authorization": f"Bearer {self._auth_token}"},
+                timeout=30.0
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            # Support both camelCase (gRPC-gateway) and snake_case
+            self._public_key = data.get("publicKey") or data.get("public_key")
+            self._address = data.get("address")
+
+            if not self._public_key or not self._address:
+                raise RuntimeError("Backend did not return valid identity")
+
+            logger.debug(f"Got identity: address={self._address}")
+
+    def sign_digest(self, digest: bytes) -> bytes:
+        """Request signature from backend.
+
+        Makes an HTTP POST to the backend's sign-bundle endpoint.
+        The backend retrieves the key from vault and signs the digest.
+
+        Args:
+            digest: 32-byte SHA256 digest to sign
+
+        Returns:
+            64-byte secp256k1 signature
+
+        Raises:
+            httpx.HTTPStatusError: If the backend request fails
+            RuntimeError: If the response is invalid
+        """
+        import httpx
+
+        logger.debug(f"Requesting signature for worker {self._worker_id}")
+        resp = httpx.post(
+            f"{self._backend_url}/api/v1/workers/{self._worker_id}/sign-bundle",
+            headers={"Authorization": f"Bearer {self._auth_token}"},
+            json={"digest_hex": digest.hex()},
+            timeout=30.0
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Check for error in response
+        if not data.get("success", True):
+            error = data.get("error", "Unknown signing error")
+            raise RuntimeError(f"Signing failed: {error}")
+
+        # Support both camelCase and snake_case
+        signature_hex = (
+            data.get("signature") or
+            data.get("signatureHex") or
+            data.get("signature_hex")
+        )
+
+        if not signature_hex:
+            raise RuntimeError("Backend did not return signature")
+
+        logger.debug("Signature received successfully")
+        return bytes.fromhex(signature_hex)
+
+    @property
+    def public_key_hex(self) -> str:
+        """Get hex-encoded compressed public key."""
+        self._ensure_identity()
+        return self._public_key
+
+    @property
+    def address(self) -> str:
+        """Get bech32 wallet address."""
+        self._ensure_identity()
+        return self._address
+
+
+# Type alias for convenience
+LocalWallet = "cosmpy.aerial.wallet.LocalWallet"

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -231,6 +231,10 @@ class AlloraWorker:
 
     def _init_wallet(self, wallet: AlloraWalletConfig | None):
         if wallet:
+            # Pre-initialized wallet takes highest precedence
+            if wallet.wallet is not None:
+                logger.info("Wallet initialized from LocalWallet")
+                return wallet.wallet
             if wallet.private_key:
                 return LocalWallet(PrivateKey(bytes.fromhex(wallet.private_key)), prefix=wallet.prefix)
             if wallet.mnemonic:

--- a/tests/test_signer_unit.py
+++ b/tests/test_signer_unit.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for Signer Protocol and implementations.
+
+Tests cover:
+- LocalWalletSigner initialization and signing
+- VaultSigner with mocked HTTP calls
+- AlloraWalletConfig.get_signer() priority
+- Protocol compliance
+
+Note: These tests use direct file imports to avoid triggering the main SDK
+__init__.py which requires generated protobuf files. This allows running
+tests without the full proto generation step.
+"""
+
+import sys
+import os
+import importlib.util
+
+# Direct file loading to bypass __init__.py files that import protos
+def _load_module(name: str, path: str):
+    """Load a module directly from file path without triggering package __init__.py"""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+# Get the src directory path
+_src_dir = os.path.join(os.path.dirname(__file__), '..', 'src')
+
+# Pre-populate sys.modules to prevent automatic loading of __init__.py files
+sys.modules['allora_sdk'] = type(sys)('allora_sdk')
+sys.modules['allora_sdk'].__path__ = [os.path.join(_src_dir, 'allora_sdk')]
+sys.modules['allora_sdk.rpc_client'] = type(sys)('allora_sdk.rpc_client')
+sys.modules['allora_sdk.rpc_client'].__path__ = [os.path.join(_src_dir, 'allora_sdk', 'rpc_client')]
+
+# Load modules directly from files
+_signer_module = _load_module(
+    'allora_sdk.rpc_client.signer',
+    os.path.join(_src_dir, 'allora_sdk', 'rpc_client', 'signer.py')
+)
+_config_module = _load_module(
+    'allora_sdk.rpc_client.config',
+    os.path.join(_src_dir, 'allora_sdk', 'rpc_client', 'config.py')
+)
+
+import pytest
+from unittest.mock import Mock, patch
+
+# Extract classes from loaded modules
+Signer = _signer_module.Signer
+LocalWalletSigner = _signer_module.LocalWalletSigner
+VaultSigner = _signer_module.VaultSigner
+AlloraWalletConfig = _config_module.AlloraWalletConfig
+
+
+# Test constants
+TEST_PRIVATE_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+TEST_DIGEST = bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+
+class TestLocalWalletSigner:
+    """Tests for LocalWalletSigner"""
+
+    def test_init_with_private_key(self):
+        """Should initialize from private key with correct prefix"""
+        signer = LocalWalletSigner(private_key=TEST_PRIVATE_KEY)
+        assert signer.address.startswith("allo")
+        assert len(signer.public_key_hex) == 66  # Compressed pubkey
+
+    def test_init_with_private_key_custom_prefix(self):
+        """Should respect custom prefix"""
+        signer = LocalWalletSigner(private_key=TEST_PRIVATE_KEY, prefix="fetch")
+        assert signer.address.startswith("fetch")
+
+    def test_init_with_mnemonic(self):
+        """Should initialize from mnemonic"""
+        signer = LocalWalletSigner(mnemonic=TEST_MNEMONIC)
+        assert signer.address.startswith("allo")
+
+    def test_init_with_wallet(self):
+        """Should accept pre-initialized LocalWallet"""
+        from cosmpy.aerial.wallet import LocalWallet, PrivateKey
+        pk = PrivateKey(bytes.fromhex(TEST_PRIVATE_KEY))
+        wallet = LocalWallet(pk, prefix="allo")
+
+        signer = LocalWalletSigner(wallet=wallet)
+        assert signer.address == str(wallet.address())
+
+    def test_init_no_credentials_raises(self):
+        """Should raise ValueError when no credentials provided"""
+        with pytest.raises(ValueError, match="Must provide"):
+            LocalWalletSigner()
+
+    def test_sign_digest(self):
+        """Should produce valid signature"""
+        signer = LocalWalletSigner(private_key=TEST_PRIVATE_KEY)
+        signature = signer.sign_digest(TEST_DIGEST)
+        assert isinstance(signature, bytes)
+        assert len(signature) == 64  # secp256k1 signature
+
+    def test_wallet_property(self):
+        """Should expose underlying LocalWallet"""
+        signer = LocalWalletSigner(private_key=TEST_PRIVATE_KEY)
+        assert signer.wallet is not None
+        assert str(signer.wallet.address()) == signer.address
+
+
+class TestVaultSigner:
+    """Tests for VaultSigner with mocked HTTP"""
+
+    def test_init(self):
+        """Should store configuration"""
+        signer = VaultSigner(
+            backend_url="http://localhost:8080",
+            worker_id="test-worker-id",
+            auth_token="test-token"
+        )
+        assert signer._backend_url == "http://localhost:8080"
+        assert signer._worker_id == "test-worker-id"
+
+    def test_init_strips_trailing_slash(self):
+        """Should strip trailing slash from backend URL"""
+        signer = VaultSigner(
+            backend_url="http://localhost:8080/",
+            worker_id="test-id",
+            auth_token="token"
+        )
+        assert signer._backend_url == "http://localhost:8080"
+
+    @patch('httpx.get')
+    def test_get_identity_lazy_loads(self, mock_get):
+        """Should lazy-load identity on first access"""
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "publicKey": "02abc123",
+                "address": "allo1xyz"
+            }
+        )
+        mock_get.return_value.raise_for_status = Mock()
+
+        signer = VaultSigner(
+            backend_url="http://localhost:8080",
+            worker_id="test-id",
+            auth_token="token"
+        )
+
+        # Should not call until accessed
+        mock_get.assert_not_called()
+
+        # Access triggers call
+        assert signer.address == "allo1xyz"
+        mock_get.assert_called_once()
+
+        # Second access uses cache
+        assert signer.public_key_hex == "02abc123"
+        mock_get.assert_called_once()  # Still just one call
+
+    @patch('httpx.post')
+    def test_sign_digest(self, mock_post):
+        """Should call backend API for signing"""
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "success": True,
+                "signatureHex": "deadbeef" * 16  # 64 bytes hex
+            }
+        )
+        mock_post.return_value.raise_for_status = Mock()
+
+        signer = VaultSigner(
+            backend_url="http://localhost:8080",
+            worker_id="test-id",
+            auth_token="token"
+        )
+
+        signature = signer.sign_digest(TEST_DIGEST)
+
+        assert isinstance(signature, bytes)
+        assert len(signature) == 64
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert "sign-bundle" in call_args[0][0]
+
+    @patch('httpx.post')
+    def test_sign_digest_supports_snake_case_response(self, mock_post):
+        """Should handle snake_case response fields"""
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "success": True,
+                "signature_hex": "abcd" * 32  # 64 bytes hex
+            }
+        )
+        mock_post.return_value.raise_for_status = Mock()
+
+        signer = VaultSigner(
+            backend_url="http://localhost:8080",
+            worker_id="test-id",
+            auth_token="token"
+        )
+
+        signature = signer.sign_digest(TEST_DIGEST)
+        assert len(signature) == 64
+
+    @patch('httpx.post')
+    def test_sign_digest_error_handling(self, mock_post):
+        """Should handle signing errors"""
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "success": False,
+                "error": "Worker not found"
+            }
+        )
+        mock_post.return_value.raise_for_status = Mock()
+
+        signer = VaultSigner(
+            backend_url="http://localhost:8080",
+            worker_id="test-id",
+            auth_token="token"
+        )
+
+        with pytest.raises(RuntimeError, match="Worker not found"):
+            signer.sign_digest(TEST_DIGEST)
+
+
+class TestAlloraWalletConfigGetSigner:
+    """Tests for AlloraWalletConfig.get_signer()"""
+
+    def test_get_signer_from_private_key(self):
+        """Should create LocalWalletSigner from private_key"""
+        config = AlloraWalletConfig(private_key=TEST_PRIVATE_KEY)
+        signer = config.get_signer()
+        assert isinstance(signer, LocalWalletSigner)
+        assert signer.address.startswith("allo")
+
+    def test_get_signer_from_mnemonic(self):
+        """Should create LocalWalletSigner from mnemonic"""
+        config = AlloraWalletConfig(mnemonic=TEST_MNEMONIC)
+        signer = config.get_signer()
+        assert isinstance(signer, LocalWalletSigner)
+
+    def test_get_signer_custom_signer_priority(self):
+        """Custom signer should take precedence"""
+        custom_signer = Mock(spec=Signer)
+        config = AlloraWalletConfig(
+            private_key=TEST_PRIVATE_KEY,  # Also provided
+            signer=custom_signer           # Should take precedence
+        )
+        assert config.get_signer() is custom_signer
+
+    def test_config_validation_with_signer(self):
+        """Should accept signer as valid credential"""
+        custom_signer = Mock(spec=Signer)
+        config = AlloraWalletConfig(signer=custom_signer)
+        # Should not raise
+        assert config.signer is custom_signer
+
+    def test_get_signer_respects_prefix(self):
+        """Should pass prefix to LocalWalletSigner"""
+        config = AlloraWalletConfig(private_key=TEST_PRIVATE_KEY, prefix="cosmos")
+        signer = config.get_signer()
+        assert signer.address.startswith("cosmos")
+
+
+class TestSignerProtocol:
+    """Tests for Signer Protocol compliance"""
+
+    def test_local_wallet_signer_is_signer(self):
+        """LocalWalletSigner should satisfy Signer protocol"""
+        signer = LocalWalletSigner(private_key=TEST_PRIVATE_KEY)
+        assert isinstance(signer, Signer)
+
+    @patch('httpx.get')
+    @patch('httpx.post')
+    def test_vault_signer_is_signer(self, mock_post, mock_get):
+        """VaultSigner should satisfy Signer protocol"""
+        mock_get.return_value = Mock(
+            json=lambda: {"publicKey": "02abc", "address": "allo1xyz"}
+        )
+        mock_get.return_value.raise_for_status = Mock()
+        mock_post.return_value = Mock(
+            json=lambda: {"success": True, "signatureHex": "ab" * 64}
+        )
+        mock_post.return_value.raise_for_status = Mock()
+
+        signer = VaultSigner(
+            backend_url="http://localhost:8080",
+            worker_id="test-id",
+            auth_token="token"
+        )
+        assert isinstance(signer, Signer)
+
+    def test_signer_protocol_methods(self):
+        """Signer protocol should define required methods"""
+        # Verify the protocol has the expected attributes
+        assert hasattr(Signer, 'sign_digest')
+        assert hasattr(Signer, 'public_key_hex')
+        assert hasattr(Signer, 'address')


### PR DESCRIPTION
## Summary

Introduces a **Signer Protocol** abstraction that enables multiple credential sources to provide a unified signing interface, supporting both self-hosted and platform-hosted (Forge) deployments.

Fixes: ENGN-4674

## Changes

### New: Signer Protocol (`signer.py`)
- `Signer` - Protocol defining `sign_digest()`, `public_key_hex`, `address`
- `LocalWalletSigner` - Wraps cosmpy LocalWallet for local signing
- `VaultSigner` - Delegates signing to backend API (for Forge platform)

### Modified: AlloraWalletConfig (`config.py`)
- Added optional `signer` field for custom Signer implementations
- Added `get_signer()` method with priority: signer > wallet > private_key > mnemonic

### Fixed: AlloraWorker (`worker/worker.py`)
- Bug fix: `wallet.wallet` field was being ignored

### Tests
- 21 unit tests in `tests/test_signer_unit.py`

## Backward Compatibility

✅ **100% backward compatible** - No changes required for existing users

| Credential Type | Before | After |
|-----------------|--------|-------|
| `private_key` | ✅ Works | ✅ Works |
| `mnemonic` | ✅ Works | ✅ Works |
| `mnemonic_file` | ✅ Works | ✅ Works |
| `wallet` | ❌ Ignored (bug) | ✅ Works (fixed) |
| `signer` | N/A | ✅ New option |

## Test Plan

- [x] All 21 unit tests pass
- [x] LocalWalletSigner produces correct addresses with `allo` prefix
- [x] VaultSigner correctly calls backend API (mocked)
- [x] Protocol compliance verified for both implementations