### PR TITLE
Add AlloraWorker.forecaster() for multi-inferer predictions

### DIFF
--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,4 +1,4 @@
-from .worker import AlloraWorker
+from .worker import AlloraWorker, PredictionResult, ForecastResult
 from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig, TxManager, FeeTier
 from .api_client import AlloraAPIClient
 from .logging_config import setup_sdk_logging
@@ -6,6 +6,8 @@ from cosmpy.aerial.wallet import LocalWallet, PrivateKey
 
 __all__ = [
     "AlloraWorker",
+    "PredictionResult",
+    "ForecastResult",
     "AlloraRPCClient",
     "AlloraAPIClient",
     "AlloraNetworkConfig",

--- a/src/allora_sdk/worker/__init__.py
+++ b/src/allora_sdk/worker/__init__.py
@@ -6,9 +6,18 @@ Provides automatic WebSocket subscription management, environment-aware signal h
 and graceful resource cleanup for submitting predictions to Allora network topics.
 """
 
-from .worker import AlloraWorker, PredictFnResultType
+from .worker import (
+    AlloraWorker,
+    PredictFnResultType,
+    PredictionResult,
+    ForecastFnResultType,
+    ForecastResult,
+)
 
 __all__ = [
     "AlloraWorker",
     "PredictFnResultType",
+    "PredictionResult",
+    "ForecastFnResultType",
+    "ForecastResult",
 ]


### PR DESCRIPTION
## Summary

- Adds `AlloraWorker.forecaster()` factory method for creating forecaster workers
- Forecasters submit predictions for multiple inferers in a single transaction
- New `ForecastResult` dataclass returns forecasts dict and transaction result
- SDK handles conversion from `Dict[str, float]` to `forecast_elements` format

## Changes

- Add `ForecastFnResultType = Dict[str, float]` and `ForecastFn` types
- Add `ForecastResult` dataclass with `forecasts` and `tx_result` fields
- Add `AlloraWorker.forecaster()` factory method
- Add `is_forecaster` flag to `__init__`
- Refactor `_submit()` to branch on worker type
- Add `_submit_forecast()` method for forecaster submissions
- Export new types from package `__init__.py`

## Usage

```python
async def my_forecast_fn(nonce: int) -> Dict[str, float]:
    """Return predictions for each inferer."""
    return {
        "allo1abc...": 0.95,
        "allo1def...": 0.87,
    }

worker = AlloraWorker.forecaster(
    run=my_forecast_fn,
    topic_id=13,
    network=AlloraNetworkConfig.mainnet(),
)

async for result in worker.run():
    print(f"Submitted {len(result.forecasts)} forecasts")
    print(f"TX hash: {result.tx_result.txhash}")
```

## Test plan

- [ ] Unit tests for `forecaster()` factory method
- [ ] Integration test with mock forecast function
- [ ] Verify `forecast_elements` format matches RPC expectations