### PR TITLE
[PR37] fix unresolved loss method guards/docs

### DIFF
--- a/src/allora_sdk/loss_methods/poisson.py
+++ b/src/allora_sdk/loss_methods/poisson.py
@@ -33,6 +33,9 @@ def make_poisson_loss(epsilon: float = DEFAULT_POISSON_EPSILON) -> Callable[[flo
         0.802848
     """
 
+    if epsilon <= 0:
+        raise ValueError(f"epsilon must be positive, got {epsilon}")
+
     def _poisson_loss(ground_truth: float, predicted: float) -> float:
         # Validate inputs are non-negative
         if ground_truth < 0:

--- a/src/allora_sdk/loss_methods/zptae.py
+++ b/src/allora_sdk/loss_methods/zptae.py
@@ -96,6 +96,8 @@ def make_zptae_loss(
     """
     if std <= 0:
         raise ValueError(f"std must be positive, got {std}")
+    if beta <= 0:
+        raise ValueError(f"beta must be positive, got {beta}")
 
     def _zptae_loss(ground_truth: float, predicted: float) -> float:
         # Calculate z-scores

--- a/src/allora_sdk/loss_methods/ztae.py
+++ b/src/allora_sdk/loss_methods/ztae.py
@@ -56,7 +56,7 @@ def make_ztae_loss(
 
     Example:
         >>> ztae = make_ztae_loss(std=0.02, mean=0.0)
-        >>> ztae(0.01, 0.02)  # Returns ~0.245
+        >>> ztae(0.01, 0.02)  # Returns ~0.299
     """
     if std <= 0:
         raise ValueError(f"std must be positive, got {std}")


### PR DESCRIPTION
## Summary
- Fix unresolved loss-method review comments for ZTAE doc accuracy and input validation.
- Update `make_poisson_loss` to require positive epsilon.
- Update `make_zptae_loss` to require positive beta and fail fast.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257705
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257710

## Test plan
- [x] Read/lint checks on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fail-fast validation to Poisson and ZPTAE loss creators to prevent invalid params, and correct the ZTAE example to reflect actual output.

- **Bug Fixes**
  - Require epsilon > 0 in make_poisson_loss; raise ValueError otherwise.
  - Require beta > 0 in make_zptae_loss; raise ValueError otherwise.
  - Update ZTAE example result to ~0.299 to reflect real computation.

<sup>Written for commit a71f4acf46de5d6009c0d06f6f5c55cb89a1c30e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

