### PR TITLE
[PR37] fix unresolved template/utils/example issues

### DIFF
--- a/example_reputer.py
+++ b/example_reputer.py
@@ -1,5 +1,8 @@
 import asyncio
+import logging
 from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker
+
+logger = logging.getLogger(__name__)
 
 def get_ground_truth(nonce: int) -> float:
     return 10.5
@@ -15,6 +18,7 @@ async def main():
 
     async for result in worker.run():
         if isinstance(result, Exception):
+            logger.error("Reputer worker error: %s", result)
             continue
         print(f"Reputer payload submitted to Allora: {result.submission}")
 

--- a/scripts/templates/rest_client.py.jinja
+++ b/scripts/templates/rest_client.py.jinja
@@ -43,8 +43,7 @@ class {{ service.class_name }}({{ service.protocol_name }}):
 {%- endif %}
         url = self.base_url + f"{{ method.url_path }}"
         headers = {"x-cosmos-block-height": height} if height else None
-        async with self.session as session:
-            response = await session.get(url, params=params, headers=headers)
+        response = await self.session.get(url, params=params, headers=headers)
         response.raise_for_status()
         return {{ method.response_type_name }}().from_json(response.text, ignore_unknown_fields=True)
 

--- a/src/allora_sdk/rpc_client/client_websocket_events.py
+++ b/src/allora_sdk/rpc_client/client_websocket_events.py
@@ -47,8 +47,6 @@ class TBetterproto2Message(Protocol):
     # __name__: ClassVar[str]
     pass
 
-T = TypeVar('T', bound=TBetterproto2Message)
-
 class NewBlockEventsData(BaseModel):
     height: str
     events: List[Any]  # Could be more specific based on actual event structure

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -97,7 +97,7 @@ class Forecaster:
         resp = await self.client.emissions.query.get_unfulfilled_worker_nonces(
             GetUnfulfilledWorkerNoncesRequest(topic_id=self.topic_id)
         )
-        nonces = {x.block_height for x in resp.nonces.nonces} if resp.nonces is not None else set[int]()
+        nonces = {x.block_height for x in resp.nonces.nonces} if resp.nonces is not None else set()
         return nonces
 
     async def handle_rewards_settled(self, event: EventRewardsSettled, block_height: int | None = None) -> None:

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -10,6 +10,7 @@ from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetNodeI
 
 
 def init_worker_wallet(wallet: AlloraWalletConfig | None) -> LocalWallet:
+    wallet_prefix = wallet.prefix if wallet else "allo"
     if wallet:
         if wallet.private_key:
             return LocalWallet(PrivateKey(bytes.fromhex(wallet.private_key)), prefix=wallet.prefix)
@@ -24,7 +25,7 @@ def init_worker_wallet(wallet: AlloraWalletConfig | None) -> LocalWallet:
     if os.path.exists(mnemonic_file):
         with open(mnemonic_file, "r") as f:
             mnemonic = f.read().strip()
-            return LocalWallet.from_mnemonic(mnemonic, "allo")
+            return LocalWallet.from_mnemonic(mnemonic, wallet_prefix)
     else:
         print("Enter your Allora wallet mnemonic or press <ENTER> to have one generated for you.")
         mnemonic = getpass("Mnemonic: ").strip()
@@ -35,7 +36,7 @@ def init_worker_wallet(wallet: AlloraWalletConfig | None) -> LocalWallet:
         with os.fdopen(fd, "w") as f:
             f.write(mnemonic)
         print(f"Mnemonic saved to {mnemonic_file}")
-        return LocalWallet.from_mnemonic(mnemonic, "allo")
+        return LocalWallet.from_mnemonic(mnemonic, wallet_prefix)
 
 
 R = TypeVar("R")


### PR DESCRIPTION
## Summary
- Resolve unresolved review threads for generated REST template session usage, worker wallet prefix handling, websocket TypeVar cleanup, forecaster set construction clarity, and reputer example error logging.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257751
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257748
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257752
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257755
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2838541932

## Test plan
- [x] Lint diagnostics clean on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes REST client session handling and fixes mnemonic wallet prefix usage. Adds error logging to the reputer example and small cleanups for clarity and reliability.

- **Bug Fixes**
  - Reuse existing HTTP session in generated REST client calls.
  - Preserve configured wallet prefix when loading/saving mnemonic wallets.
  - Fix empty set creation in forecaster (use set()).
  - Log exceptions in example_reputer.py when the worker yields an error.

- **Refactors**
  - Remove unused TypeVar from the websocket events module.

<sup>Written for commit fc43b3c72ac1ada85c5d41d4b813b29f1f3f4d8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

