### PR TITLE
[PR37] fix unresolved RPC client typing/staking behavior

### DIFF
--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -203,7 +203,7 @@ class EmissionsTxs:
     async def add_stake(
         self,
         topic_id: int,
-        amount: int,
+        amount: str,
         fee_tier: FeeTier = FeeTier.STANDARD,
     ) -> PendingTx:
         """
@@ -211,7 +211,7 @@ class EmissionsTxs:
 
         Args:
             topic_id: The topic ID to stake on
-            amount: Amount of uallo to stake
+            amount: Amount of uallo to stake (as string)
             fee_tier: Fee tier (ECO/STANDARD/PRIORITY) - defaults to STANDARD
 
         Returns:
@@ -225,7 +225,7 @@ class EmissionsTxs:
         msg = AddStakeRequest(
             sender=sender_address,
             topic_id=topic_id,
-            amount=str(amount),
+            amount=amount,
         )
 
         logger.debug(f"Adding stake of {amount} uallo to topic {topic_id}")

--- a/src/allora_sdk/rpc_client/client_staking.py
+++ b/src/allora_sdk/rpc_client/client_staking.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Optional, Protocol
 
 from allora_sdk.rpc_client.protos.cosmos.base.v1beta1 import Coin
 from allora_sdk.rpc_client.protos.cosmos.staking.v1beta1 import (
@@ -12,10 +12,18 @@ from allora_sdk.rpc_client.tx_manager import FeeTier, PendingTx, TxManager
 logger = logging.getLogger("allora_sdk")
 
 
+class StakingQueryResponseLike(Protocol):
+    validator: Validator | None
+
+
+class StakingQueryClientLike(Protocol):
+    async def validator(self, request: QueryValidatorRequest) -> StakingQueryResponseLike: ...
+
+
 class StakingQueries:
     """Query methods for the Cosmos staking module."""
 
-    def __init__(self, query_client: Any):
+    def __init__(self, query_client: StakingQueryClientLike | None):
         self._query_client = query_client
 
     async def validator(self, validator_address: str) -> Validator | None:
@@ -50,8 +58,8 @@ class StakingClient:
     Currently used for validator delegation (MsgDelegate) via TxManager.
     """
 
-    def __init__(self, query_client: Any = None, tx_manager: TxManager | None = None):
-        self.query = StakingQueries(query_client) if query_client is not None else None
+    def __init__(self, query_client: StakingQueryClientLike | None = None, tx_manager: TxManager | None = None):
+        self.query = StakingQueries(query_client)
         self.tx = StakingTxs(txs=tx_manager)
 
 

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -358,7 +358,7 @@ class Reputer:
         try:
             pending_tx = await self.client.emissions.tx.add_stake(
                 topic_id=self.topic_id,
-                amount=delta,
+                amount=str(delta),
                 fee_tier=self.fee_tier,
             )
             tx_resp = await pending_tx.wait()


### PR DESCRIPTION
## Summary
- Resolve unresolved RPC client type-safety and staking behavior review items.
- Always expose `client.staking.query` as a query wrapper so unsupported transports raise a descriptive error instead of `NoneType` attribute errors.
- Replace `Any` in staking query client constructor paths with Protocol-based typing.
- Align `add_stake` amount typing with string-based uallo usage for consistency.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257743
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579525
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257734

## Test plan
- [x] Lint diagnostics clean on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes staking query exposure to prevent NoneType errors and tightens RPC client typing with Protocols. Also updates add_stake to accept string uallo amounts for consistency.

- **Bug Fixes**
  - Always expose client.staking.query; unsupported transports now raise a clear error.
  - Use Protocol-based types for staking queries to improve type-safety.

- **Migration**
  - Pass amount as a string (uallo) to emissions.tx.add_stake, e.g., "1000000".

<sup>Written for commit 599950339a0c2d3a649a91f9b27c0c3d040ff91b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

