### PR TITLE
[PR37] fix unresolved tx manager concurrency/cache

### DIFF
--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -54,6 +54,7 @@ class AlloraNetworkConfig:
     fee_minimum_gas_price: float = 10.0
     faucet_url: Optional[str] = None
     use_dynamic_gas_price: bool = True
+    dynamic_gas_price_default_multiplier: float = 10.0
     gas_price_cache_ttl_secs: int = 30
     congestion_aware_fees: bool = False
     query_timeout_secs: int = 10
@@ -68,6 +69,7 @@ class AlloraNetworkConfig:
         fee_denom="uallo",
         fee_minimum_gas_price=10.0,
         use_dynamic_gas_price=True,
+        dynamic_gas_price_default_multiplier=10.0,
         gas_price_cache_ttl_secs=30,
         congestion_aware_fees=False,
     ) -> 'AlloraNetworkConfig':
@@ -79,6 +81,7 @@ class AlloraNetworkConfig:
             fee_denom=fee_denom,
             fee_minimum_gas_price=fee_minimum_gas_price,
             use_dynamic_gas_price=use_dynamic_gas_price,
+            dynamic_gas_price_default_multiplier=dynamic_gas_price_default_multiplier,
             gas_price_cache_ttl_secs=gas_price_cache_ttl_secs,
             congestion_aware_fees=congestion_aware_fees,
         )
@@ -92,6 +95,7 @@ class AlloraNetworkConfig:
         fee_denom="uallo",
         fee_minimum_gas_price=250_000_000.0,
         use_dynamic_gas_price=True,
+        dynamic_gas_price_default_multiplier=10.0,
         gas_price_cache_ttl_secs=30,
         congestion_aware_fees=False,
     ) -> 'AlloraNetworkConfig':
@@ -102,6 +106,7 @@ class AlloraNetworkConfig:
             fee_denom=fee_denom,
             fee_minimum_gas_price=fee_minimum_gas_price,
             use_dynamic_gas_price=use_dynamic_gas_price,
+            dynamic_gas_price_default_multiplier=dynamic_gas_price_default_multiplier,
             gas_price_cache_ttl_secs=gas_price_cache_ttl_secs,
             congestion_aware_fees=congestion_aware_fees,
         )
@@ -114,6 +119,7 @@ class AlloraNetworkConfig:
         fee_denom="uallo",
         fee_minimum_gas_price=1.0,
         use_dynamic_gas_price=False,
+        dynamic_gas_price_default_multiplier=10.0,
         gas_price_cache_ttl_secs=30,
         congestion_aware_fees=False,
         query_timeout_secs=30,
@@ -127,6 +133,7 @@ class AlloraNetworkConfig:
             fee_denom=fee_denom,
             fee_minimum_gas_price=fee_minimum_gas_price,
             use_dynamic_gas_price=use_dynamic_gas_price,
+            dynamic_gas_price_default_multiplier=dynamic_gas_price_default_multiplier,
             gas_price_cache_ttl_secs=gas_price_cache_ttl_secs,
             congestion_aware_fees=congestion_aware_fees,
             query_timeout_secs=query_timeout_secs,

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -652,11 +652,11 @@ class TxManager:
                     # e.g., "10000000000000000000" represents 10.0
                     price_raw = Decimal(response.price.amount)
                     price = price_raw / Decimal(10 ** 18)
-                    adjusted_price = price * Decimal(10)
+                    adjusted_price = price * Decimal(str(self.config.dynamic_gas_price_default_multiplier))
                     self._cached_gas_price = adjusted_price
                     self._gas_price_cache_time = datetime.now()
                     logger.debug(f"Using dynamic gas price: {adjusted_price} {self.config.fee_denom}/gas")
-                    # Feemarket returns the minimum acceptable price; apply a 10x buffer
+                    # Feemarket returns the minimum acceptable price; apply configured buffer
                     # to avoid "insufficient fees" rejections from validators with higher minimums.
                     return float(adjusted_price)
             except Exception as e:

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -129,6 +129,7 @@ class TxManager:
         self.query_interval_secs = query_interval_secs
         self.query_timeout_secs = query_timeout_secs
         self.parent_tx_id = 0
+        self._parent_tx_id_lock = asyncio.Lock()
 
         self._default_gas_limits = {
             "/emissions.v9.InsertWorkerPayloadRequest": 250000,
@@ -182,16 +183,19 @@ class TxManager:
             logger.debug(f"Unable to simulate transaction for gas estimate, falling back to defaults: {e}")
             estimated_gas_limit = None
 
+        async with self._parent_tx_id_lock:
+            next_parent_tx_id = self.parent_tx_id
+            self.parent_tx_id += 1
+
         pending = PendingTx(
             manager=self,
-            parent_tx_id=self.parent_tx_id,
+            parent_tx_id=next_parent_tx_id,
             type_url=type_url,
             msgs=msgs,
             fee_tier=fee_tier,
             max_retries=max_retries,
             timeout=timeout,
         )
-        self.parent_tx_id += 1
 
         # Kick off processing as a background task; caller can await the PendingTx
         asyncio.create_task(
@@ -648,12 +652,13 @@ class TxManager:
                     # e.g., "10000000000000000000" represents 10.0
                     price_raw = Decimal(response.price.amount)
                     price = price_raw / Decimal(10 ** 18)
-                    self._cached_gas_price = price
+                    adjusted_price = price * Decimal(10)
+                    self._cached_gas_price = adjusted_price
                     self._gas_price_cache_time = datetime.now()
-                    logger.debug(f"Using dynamic gas price: {price} {self.config.fee_denom}/gas")
+                    logger.debug(f"Using dynamic gas price: {adjusted_price} {self.config.fee_denom}/gas")
                     # Feemarket returns the minimum acceptable price; apply a 10x buffer
                     # to avoid "insufficient fees" rejections from validators with higher minimums.
-                    return float(price) * 10
+                    return float(adjusted_price)
             except Exception as e:
                 logger.debug(f"Failed to query dynamic gas price, using static: {e}")
 


### PR DESCRIPTION
## Summary
- Resolve unresolved tx-manager review threads around concurrent ID assignment and dynamic gas-price cache consistency.
- Protect `parent_tx_id` allocation with an async lock.
- Cache the effective buffered gas price so cached and fresh calls use identical values.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579506
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257664

## Test plan
- [x] Lint diagnostics clean on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TxManager concurrency for parent transaction ID assignment and make the dynamic gas price buffer configurable and consistently cached. Prevents ID collisions during parallel submissions and keeps fees aligned across cached and fresh queries.

- **Bug Fixes**
  - Guard parent_tx_id allocation with an asyncio.Lock to avoid duplicates on concurrent submit_transaction calls.
  - Cache and return the adjusted dynamic gas price (after multiplier) so cached and live queries match, including logs.

- **New Features**
  - Add AlloraNetworkConfig.dynamic_gas_price_default_multiplier (default 10x) and apply it across testnet, mainnet, and local configs.

<sup>Written for commit 91fc75915b43d1d0223277e26da89c68a26a2a5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

