### PR TITLE
[PR37] fix unresolved autostake reserve and reputer errors

### DIFF
--- a/src/allora_sdk/worker/autostake.py
+++ b/src/allora_sdk/worker/autostake.py
@@ -48,7 +48,7 @@ class AutoStakeConfig:
     target_type: AutoStakeTargetType
     target_address: str
     fee_tier: FeeTier | None = None
-    fee_reserve_uallo: int = 0  # TODO: reserve this amount for gas fees before staking
+    fee_reserve_uallo: int = 0
 
     def __post_init__(self) -> None:
         if isinstance(self.target_type, str):
@@ -179,6 +179,12 @@ def normalize_actor_type(actor_type: Any) -> str:
     return s
 
 
+def compute_stake_amount_uallo(reward_uallo: int, fee_reserve_uallo: int) -> int:
+    """Compute how much reward can be staked after preserving fee reserve."""
+    reserve = max(0, int(fee_reserve_uallo))
+    return max(0, int(reward_uallo) - reserve)
+
+
 async def process_autostake_rewards_settled(
     *,
     role: AutoStakeRole,
@@ -229,14 +235,26 @@ async def process_autostake_rewards_settled(
         return None
 
     fee_tier = autostake.fee_tier if autostake.fee_tier is not None else default_fee_tier
+    stake_amount_uallo = compute_stake_amount_uallo(
+        reward_uallo=reward_uallo,
+        fee_reserve_uallo=autostake.fee_reserve_uallo,
+    )
+    if stake_amount_uallo <= 0:
+        logger.info(
+            "[AUTO-STAKE] Skipping: reward_uallo=%s is not enough after fee reserve_uallo=%s",
+            reward_uallo,
+            autostake.fee_reserve_uallo,
+        )
+        return None
 
     logger.info(
-        "[AUTO-STAKE] %s rewards settled: topic=%s nonce=%s payout_height_tx=%s reward_uallo=%s target=%s:%s",
+        "[AUTO-STAKE] %s rewards settled: topic=%s nonce=%s payout_height_tx=%s reward_uallo=%s stake_amount_uallo=%s target=%s:%s",
         role.value,
         topic_id,
         getattr(event, "block_height", None),
         getattr(event, "block_height_tx", None),
         reward_uallo,
+        stake_amount_uallo,
         autostake.target_type.value,
         autostake.target_address,
     )
@@ -246,33 +264,33 @@ async def process_autostake_rewards_settled(
             logger.info(
                 "[AUTO-STAKE] Delegating to reputer: reputer=%s amount_uallo=%s fee_tier=%s",
                 autostake.target_address,
-                reward_uallo,
+                stake_amount_uallo,
                 fee_tier.value,
             )
             pending = await client.emissions.tx.delegate_stake(
                 sender=wallet_addr,
                 topic_id=topic_id,
                 reputer=autostake.target_address,
-                amount=str(reward_uallo),
+                amount=str(stake_amount_uallo),
                 fee_tier=fee_tier,
             )
             resp = await pending.wait()
             if resp.code != 0:
                 logger.error(f"[AUTO-STAKE] DelegateStake failed: code={resp.code} log={resp.raw_log}")
             else:
-                logger.info(f"[AUTO-STAKE] Delegated {reward_uallo}uallo to reputer (tx={resp.txhash})")
+                logger.info(f"[AUTO-STAKE] Delegated {stake_amount_uallo}uallo to reputer (tx={resp.txhash})")
 
         elif autostake.target_type == AutoStakeTargetType.VALIDATOR:
             logger.info(
                 "[AUTO-STAKE] Delegating to validator: validator=%s amount_uallo=%s denom=%s fee_tier=%s",
                 autostake.target_address,
-                reward_uallo,
+                stake_amount_uallo,
                 client.network.fee_denom,
                 fee_tier.value,
             )
             pending = await client.staking.tx.delegate(
                 validator_address=autostake.target_address,
-                amount_uallo=reward_uallo,
+                amount_uallo=stake_amount_uallo,
                 delegator_address=wallet_addr,
                 fee_tier=fee_tier,
             )
@@ -280,7 +298,7 @@ async def process_autostake_rewards_settled(
             if resp.code != 0:
                 logger.error(f"[AUTO-STAKE] MsgDelegate failed: code={resp.code} log={resp.raw_log}")
             else:
-                logger.info(f"[AUTO-STAKE] Delegated {reward_uallo}uallo to validator (tx={resp.txhash})")
+                logger.info(f"[AUTO-STAKE] Delegated {stake_amount_uallo}uallo to validator (tx={resp.txhash})")
 
         else:
             raise ValueError(f"Unknown autostake target_type: {autostake.target_type}")

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -227,13 +227,14 @@ class Reputer:
         async def compute_loss(value_str: str) -> str:
             try:
                 predicted = float(value_str)
-                if self.loss_fn is None:
-                    raise ValueError("no loss fn configured")
-                loss = await resolve_maybe_awaitable(self.loss_fn, ground_truth, predicted)
-                return str(loss)
-            except (ValueError, TypeError) as e:
-                logger.warning(f"Could not compute loss for value '{value_str}': {e}, defaulting to 0")
-                return "0"
+            except (ValueError, TypeError) as err:
+                raise ValueError(f"invalid numeric value for loss computation: '{value_str}'") from err
+
+            if self.loss_fn is None:
+                raise ValueError("no loss fn configured")
+
+            loss = await resolve_maybe_awaitable(self.loss_fn, ground_truth, predicted)
+            return str(loss)
 
         # Compute combined and naive losses
         combined_loss = await compute_loss(value_bundle.combined_value) if value_bundle.combined_value else "0"


### PR DESCRIPTION
## Summary
- Resolve unresolved autostake and reputer semantics threads.
- Use `fee_reserve_uallo` when calculating autostake delegation amounts.
- Fail fast on invalid reputer loss inputs / missing loss function instead of defaulting to zero.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579470
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257669
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579491

## Test plan
- [x] Lint diagnostics clean on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve gas before autostake delegation and fail fast on reputer loss errors. Prevents over-delegation and surfaces misconfigurations early.

- **Bug Fixes**
  - Autostake: subtract fee_reserve_uallo to compute stake_amount_uallo; skip delegation when amount <= 0; use stake_amount_uallo for reputer/validator delegations and logs.
  - Reputer: validate numeric inputs and require loss_fn; raise ValueError instead of defaulting loss to "0".

- **Migration**
  - Ensure a loss_fn is configured and update callers to handle ValueError from loss computation.

<sup>Written for commit 10617fba5aad43d5d70a324e07e66a1fef43be22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

