### PR TITLE
[PR37] fix unresolved worker core sequence/nonce issues

### DIFF
--- a/src/allora_sdk/worker/types.py
+++ b/src/allora_sdk/worker/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Generic, Protocol, TypeVar, Union
+from typing import Any, Awaitable, Callable, Generic, Protocol, TypeVar, Union, runtime_checkable
 from allora_sdk.rpc_client.protos.cosmos.base.abci.v1beta1 import TxResponse
 from allora_sdk.rpc_client.tx_manager import TxError
 
@@ -38,3 +38,9 @@ class UseCase(Protocol[WindowOpenedEvent, UseCaseReturnType]):
     async def worker_is_whitelisted(self) -> bool: ...
     async def get_unfulfilled_nonces(self) -> set[int]: ...
     async def submit(self, nonce: int, account_seq: int) -> Union[WorkerResult[UseCaseReturnType], TxError, Exception]: ...
+
+
+@runtime_checkable
+class SupportsAutoStake(Protocol):
+    autostake: object | None
+    async def handle_rewards_settled(self, event: Any, block_height: int | None = None) -> None: ...

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -13,7 +13,6 @@ from textwrap import dedent, indent
 import traceback
 import requests
 import logging
-import time
 from typing import Generic, Optional, AsyncIterator, TypeVar
 
 from allora_sdk.rpc_client.protos.cosmos.auth.v1beta1 import QueryAccountInfoRequest
@@ -39,7 +38,16 @@ from allora_sdk.worker.forecaster import Forecaster, TForecasterRunFn, TForecast
 from allora_sdk.worker.inferer import Inferer, TInfererRunFn, TInfererRunFnResult
 from allora_sdk.worker.reputer import GroundTruthFn, LossFn, Reputer
 from allora_sdk.worker.autostake import AutoStakeConfig
-from allora_sdk.worker.types import AlreadySubmittedError, StopQueue, TQueueItem, TSubmissionWindowOpenEventType, UseCase, WorkerNotWhitelistedError, WorkerResult
+from allora_sdk.worker.types import (
+    AlreadySubmittedError,
+    StopQueue,
+    SupportsAutoStake,
+    TQueueItem,
+    TSubmissionWindowOpenEventType,
+    UseCase,
+    WorkerNotWhitelistedError,
+    WorkerResult,
+)
 from allora_sdk.worker.utils import init_worker_wallet
 
 logger = logging.getLogger("allora_sdk")
@@ -67,6 +75,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         topic_id: int = 69,
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
+        max_unfulfilled_nonces: int = 10,
         autostake: AutoStakeConfig | None = None,
         debug: bool = False,
     ):
@@ -108,6 +117,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             topic_id=topic_id,
             fee_tier=fee_tier,
             polling_interval=polling_interval,
+            max_unfulfilled_nonces=max_unfulfilled_nonces,
             debug=debug,
         )
 
@@ -123,6 +133,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
         min_stake_uallo: Optional[int] = None,
+        max_unfulfilled_nonces: int = 10,
         debug: bool = False,
     ) -> "AlloraWorker[EventReputerSubmissionWindowOpened, InputValueBundle]":
         """
@@ -171,6 +182,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             topic_id=topic_id,
             fee_tier=fee_tier,
             polling_interval=polling_interval,
+            max_unfulfilled_nonces=max_unfulfilled_nonces,
             debug=debug,
         )
 
@@ -184,6 +196,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         topic_id: int = 69,
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
+        max_unfulfilled_nonces: int = 10,
         autostake: AutoStakeConfig | None = None,
         debug: bool = False,
     ) -> "AlloraWorker[EventWorkerSubmissionWindowOpened, TForecasterRunFnResult]":
@@ -227,6 +240,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             topic_id=topic_id,
             fee_tier=fee_tier,
             polling_interval=polling_interval,
+            max_unfulfilled_nonces=max_unfulfilled_nonces,
             debug=debug,
         )
 
@@ -240,6 +254,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         topic_id: int = 69,
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
+        max_unfulfilled_nonces: int = 10,
         debug: bool = False,
     ) -> None:
         """
@@ -253,6 +268,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             topic_id: The Allora network topic ID to submit predictions to
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
+            max_unfulfilled_nonces: Maximum number of nonces to process per cycle
             debug: Enable debug logging
         """
         if use_case is None:
@@ -268,6 +284,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         self.topic_id = topic_id
         self.fee_tier = fee_tier
         self.polling_interval = polling_interval
+        self.max_unfulfilled_nonces = max(1, max_unfulfilled_nonces)
 
         self.submitted_nonces = TimestampOrderedSet()
 
@@ -333,6 +350,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
         MIN_ALLO = 100000000
         MAX_FAUCET_RETRIES = 5
+        MAX_BALANCE_POLLS_PER_FAUCET_REQUEST = 12
 
         resp = await self.client.bank.query.balance(QueryBalanceRequest(address=self.address, denom="uallo"))
         if resp.balance is None:
@@ -360,7 +378,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
                 faucet_resp.raise_for_status()
                 logger.info(f"    Request sent...")
 
-                while True:
+                for _ in range(MAX_BALANCE_POLLS_PER_FAUCET_REQUEST):
                     await asyncio.sleep(5)
                     resp = await self.client.bank.query.balance(QueryBalanceRequest(address=self.address, denom="uallo"))
                     if resp.balance is None:
@@ -371,6 +389,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
                     logger.info(f"    Balance: {balance_formatted}")
                     if balance >= MIN_ALLO:
                         return
+                logger.warning("    Faucet request succeeded but balance did not update in time, retrying...")
             except requests.HTTPError as err:
                 if err.response.status_code == 429:
                     logger.error(f"    Too many faucet requests. Try sending ALLO to your worker's wallet manually from another wallet, or visit https://faucet.testnet.allora.network")
@@ -569,13 +588,11 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         )
 
         # Subscribe to rewards events for autostaking if configured on the use case
-        autostake_cfg = getattr(self.use_case, "autostake", None)
-        handler = getattr(self.use_case, "handle_rewards_settled", None)
-        if autostake_cfg is not None and handler is not None:
+        if isinstance(self.use_case, SupportsAutoStake) and self.use_case.autostake is not None:
             await self.client.events.subscribe_new_block_events_typed(
                 EventRewardsSettled,
                 [EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"')],
-                handler,
+                self.use_case.handle_rewards_settled,
             )
             logger.info(
                 f"   Auto-stake enabled: subscribed to rewards events for topic {self.topic_id}"
@@ -684,22 +701,21 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         base_sequence = account_seq.info.sequence
 
         new_nonces = sorted(list(new_nonces))
-        if len(new_nonces) > 10:
-            skipped = len(new_nonces) - 1
-            logger.warning(f"   {skipped} old unfulfilled nonces skipped, submitting only the latest")
-            new_nonces = new_nonces[-1:]
-        tasks = []
+        if len(new_nonces) > self.max_unfulfilled_nonces:
+            skipped = len(new_nonces) - self.max_unfulfilled_nonces
+            logger.warning(
+                f"   {skipped} old unfulfilled nonces skipped, submitting the latest {self.max_unfulfilled_nonces}"
+            )
+            new_nonces = new_nonces[-self.max_unfulfilled_nonces:]
+
         for i, nonce in enumerate(new_nonces):
             if not self._ctx or self._ctx.is_cancelled():
                 break
 
             next_sequence = base_sequence + i
             logger.info(f"👉 Found new nonce {nonce} for topic {self.topic_id}, submitting... account_seq={next_sequence}")
-            task = asyncio.create_task(submit(nonce, next_sequence))
-            tasks.append(task)
-
-        if len(tasks) > 0:
-            await asyncio.wait(tasks)
+            # Cosmos account sequence values are strictly ordered; submit serially to avoid races.
+            await submit(nonce, next_sequence)
 
 
     async def _cleanup(self, ctx: Context):

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -55,6 +55,11 @@ logger = logging.getLogger("allora_sdk")
 SubmissionWindowOpenEventType = TypeVar("SubmissionWindowOpenEventType", bound=TSubmissionWindowOpenEventType)
 WorkerFnReturnType = TypeVar("WorkerFnReturnType")
 
+# Default per-cycle cap for inferer/forecaster unfulfilled nonce processing.
+DEFAULT_MAX_UNFULFILLED_WORKER_NONCES = 10
+# Default per-cycle cap for reputer unfulfilled nonce processing.
+DEFAULT_MAX_UNFULFILLED_REPUTER_NONCES = 10
+
 
 class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     """
@@ -75,7 +80,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         topic_id: int = 69,
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
-        max_unfulfilled_nonces: int = 10,
+        max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
         autostake: AutoStakeConfig | None = None,
         debug: bool = False,
     ):
@@ -133,7 +138,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
         min_stake_uallo: Optional[int] = None,
-        max_unfulfilled_nonces: int = 10,
+        max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_REPUTER_NONCES,
         debug: bool = False,
     ) -> "AlloraWorker[EventReputerSubmissionWindowOpened, InputValueBundle]":
         """
@@ -196,7 +201,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         topic_id: int = 69,
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
-        max_unfulfilled_nonces: int = 10,
+        max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
         autostake: AutoStakeConfig | None = None,
         debug: bool = False,
     ) -> "AlloraWorker[EventWorkerSubmissionWindowOpened, TForecasterRunFnResult]":
@@ -254,7 +259,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         topic_id: int = 69,
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
-        max_unfulfilled_nonces: int = 10,
+        max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
         debug: bool = False,
     ) -> None:
         """


### PR DESCRIPTION
## Summary
- Resolve unresolved worker-core review threads around nonce truncation policy, sequence race conditions, faucet polling boundedness, and autostake subscription type safety.
- Add configurable `max_unfulfilled_nonces` with sliding-window truncation.
- Submit nonces serially to preserve strict account sequence ordering.
- Bound faucet balance polling attempts after successful faucet requests.
- Replace `getattr` autostake duck-typing with a protocol-based runtime check.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579440
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2829257686
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579445
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2834442386
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579451

## Test plan
- [x] Lint diagnostics clean on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nonce ordering and faucet polling to prevent account-sequence errors and hangs. Adds a configurable per-cycle cap for unfulfilled nonces with role-based defaults and replaces getattr autostake wiring with a runtime-checked protocol.

- **Bug Fixes**
  - Submit nonces serially to avoid Cosmos account-sequence races.
  - Truncate old unfulfilled nonces with a sliding window; cap per cycle and log skipped items.
  - After a successful faucet request, poll balance up to 12 times before retrying.

- **New Features**
  - Add max_unfulfilled_nonces to inferer, reputer, forecaster, and AlloraWorker; role-specific defaults via named constants.
  - Use a runtime-checkable SupportsAutoStake protocol for safe autostake event subscription.

<sup>Written for commit f5171ff7568d7db2a8f8388a9eca1b4b8bbecd1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

