### PR TITLE
[PR37] fix unresolved forecaster payload semantics

### DIFF
--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -102,6 +102,9 @@ class EmissionsTxs:
         if not self._txs:
             raise Exception("No wallet configured. Initialize client with private key or mnemonic.")
 
+        if inference_value is None and not forecast_elements:
+            raise ValueError("At least one of inference_value or forecast_elements must be provided.")
+
         worker_address = str(self._txs.wallet.address())
 
         inference = None

--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -74,7 +74,7 @@ class EmissionsTxs:
     async def insert_worker_payload(
         self,
         topic_id: int,
-        inference_value: str,
+        inference_value: Optional[str],
         nonce: int,
         forecast_elements: Optional[List[Dict[str, str]]] = None,
         extra_data: Optional[bytes] = None,
@@ -87,7 +87,7 @@ class EmissionsTxs:
 
         Args:
             topic_id: The topic ID to submit inference for
-            inference_value: The inference value as a string
+            inference_value: Optional inference value as a string. Set to None for forecast-only payloads.
             nonce: Block height/nonce for the inference
             forecast_elements: Optional list of forecast elements
                               [{"inferer": "address", "value": "prediction"}]
@@ -104,14 +104,16 @@ class EmissionsTxs:
 
         worker_address = str(self._txs.wallet.address())
 
-        inference = InputInference(
-            topic_id=topic_id,
-            block_height=nonce,
-            inferer=worker_address,
-            value=inference_value,
-            extra_data=extra_data or b"",
-            proof=proof or ""
-        )
+        inference = None
+        if inference_value is not None:
+            inference = InputInference(
+                topic_id=topic_id,
+                block_height=nonce,
+                inferer=worker_address,
+                value=inference_value,
+                extra_data=extra_data or b"",
+                proof=proof or "",
+            )
 
         forecast = None
         if forecast_elements:

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -143,12 +143,9 @@ class Forecaster:
                 for addr, pred in sorted(forecasts.items(), key=lambda kv: kv[0])
             ]
 
-            # Calculate aggregate for inference_value (required field).
-            aggregate = sum(forecasts.values()) / len(forecasts)
-
             pending = await self.client.emissions.tx.insert_worker_payload(
                 topic_id=self.topic_id,
-                inference_value=str(aggregate),
+                inference_value=None,
                 nonce=nonce,
                 forecast_elements=forecast_elements,
                 fee_tier=self.fee_tier,


### PR DESCRIPTION
## Summary
- Resolve unresolved forecaster semantics thread around synthetic inference values.
- Allow `insert_worker_payload` to accept `inference_value=None`.
- Submit forecaster payloads as forecast-only without generating a mean inference value.

## Review thread mapping
- https://github.com/allora-network/allora-sdk-py/pull/37#discussion_r2823579556

## Test plan
- [x] Lint diagnostics clean on touched files
- [ ] Full test suite (deferred to batch run)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow forecast-only submissions by making inference_value optional and removing synthetic mean aggregation. Add strict validation to require either inference_value or forecast_elements.

- **Bug Fixes**
  - insert_worker_payload accepts Optional[str]; raises ValueError if both inference_value and forecast_elements are missing; only builds InputInference when a value is provided.
  - Forecaster submits inference_value=None with forecast_elements; removes aggregate computation.

<sup>Written for commit bac50cd20b1f88d49a54c3cf6d3e6eca897888a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

