### PR TITLE
[PR37] Harden reputer loss safety

### DIFF
--- a/src/allora_sdk/loss_methods/defaults.py
+++ b/src/allora_sdk/loss_methods/defaults.py
@@ -76,6 +76,16 @@ def _normalize_loss_method(loss_method: str) -> str:
     return normalized
 
 
+# Loss methods that require explicit custom loss_fn (cannot be auto-selected)
+_LOSS_METHODS_REQUIRING_EXPLICIT_CONFIG: frozenset[str] = frozenset({"ztae", "zptae"})
+
+
+def requires_explicit_loss_fn(loss_method: str) -> bool:
+    """Return True if the loss method requires an explicit custom loss_fn."""
+    normalized = _normalize_loss_method(loss_method)
+    return normalized in _LOSS_METHODS_REQUIRING_EXPLICIT_CONFIG
+
+
 def is_supported_loss_method(loss_method: str) -> bool:
     normalized = _normalize_loss_method(loss_method)
     return normalized in _LOSS_FUNCTIONS

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import logging
+import math
 from typing import Awaitable, Callable, List, Optional, Union
 from cosmpy.aerial.wallet import LocalWallet
 
@@ -19,7 +20,13 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     IsReputerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
-from allora_sdk.loss_methods.defaults import LossFn, get_default_loss_fn, is_supported_loss_method, UnsupportedLossMethodError
+from allora_sdk.loss_methods.defaults import (
+    LossFn,
+    get_default_loss_fn,
+    is_supported_loss_method,
+    requires_explicit_loss_fn,
+    UnsupportedLossMethodError,
+)
 from allora_sdk.loss_methods.squared_error import squared_error_loss
 from allora_sdk.utils.format import uallo_to_allo
 from allora_sdk.worker.types import AlreadySubmittedError, UseCase, WorkerResult
@@ -122,6 +129,10 @@ class Reputer:
 
             ground_truth_raw = await resolve_maybe_awaitable(self.ground_truth_fn, nonce)
             ground_truth = float(ground_truth_raw)
+            if not math.isfinite(ground_truth):
+                raise ValueError(
+                    f"ground_truth must be finite (got non-finite value: {ground_truth})"
+                )
         except Exception as err:
             logger.error(f"❌ Ground truth function failed: {err}")
             return err
@@ -215,6 +226,14 @@ class Reputer:
                 supported=["sqe", "abse", "huber", "logcosh", "bce", "poisson", "ztae", "zptae"],
             )
 
+        if requires_explicit_loss_fn(loss_method):
+            raise ValueError(
+                f"Topic uses loss_method='{loss_method}' which requires explicit configuration. "
+                "Provide a custom loss_fn using make_ztae_loss() or make_zptae_loss() with "
+                "the appropriate standard deviation for your data: "
+                "e.g. loss_fn=make_ztae_loss(std=0.02) or loss_fn=make_zptae_loss(std=0.02)."
+            )
+
         self.loss_fn = get_default_loss_fn(loss_method)
         logger.info(f"Auto-selected loss function for topic loss_method='{loss_method}'")
 
@@ -224,11 +243,21 @@ class Reputer:
 
         Computes losses for combined, naive, inferer, forecaster, one-out, and one-in values.
         """
+        if not math.isfinite(ground_truth):
+            raise ValueError(
+                f"ground_truth must be finite (got non-finite value: {ground_truth})"
+            )
+
         async def compute_loss(value_str: str) -> str:
             try:
                 predicted = float(value_str)
             except (ValueError, TypeError) as err:
                 raise ValueError(f"invalid numeric value for loss computation: '{value_str}'") from err
+
+            if not math.isfinite(predicted):
+                raise ValueError(
+                    f"predicted must be finite (got non-finite value: {predicted})"
+                )
 
             if self.loss_fn is None:
                 raise ValueError("no loss fn configured")

--- a/tests/test_reputer_loss_safety.py
+++ b/tests/test_reputer_loss_safety.py
@@ -1,0 +1,177 @@
+"""Tests for reputer loss computation safety (non-finite handling, ztae/zptae config)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from allora_sdk.loss_methods.defaults import requires_explicit_loss_fn
+from allora_sdk.loss_methods.squared_error import squared_error_loss
+from allora_sdk.loss_methods.ztae import make_ztae_loss
+from allora_sdk.loss_methods.zptae import make_zptae_loss
+from allora_sdk.worker.reputer import Reputer
+
+
+# ---------------------------------------------------------------------------
+# Non-finite input handling in _compute_loss_bundle
+# ---------------------------------------------------------------------------
+
+
+def _make_value_bundle(combined_value: str, naive_value: str = "0") -> Mock:
+    vb = Mock()
+    vb.combined_value = combined_value
+    vb.naive_value = naive_value
+    vb.inferer_values = []
+    vb.forecaster_values = []
+    vb.one_out_inferer_values = []
+    vb.one_out_forecaster_values = []
+    vb.one_in_forecaster_values = []
+    vb.one_out_inferer_forecaster_values = []
+    return vb
+
+
+@pytest.fixture
+def reputer_with_sqe():
+    wallet = Mock()
+    wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
+    client = Mock()
+    return Reputer(
+        wallet=wallet,
+        client=client,
+        topic_id=1,
+        ground_truth_fn=lambda _: 10.0,
+        loss_fn=squared_error_loss,
+    )
+
+
+class TestComputeLossBundleNonFinite:
+    """Test that _compute_loss_bundle rejects non-finite ground_truth and predicted values."""
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_nan_raises(self, reputer_with_sqe):
+        vb = _make_value_bundle(combined_value="5.0", naive_value="5.0")
+        with pytest.raises(ValueError) as exc_info:
+            await reputer_with_sqe._compute_loss_bundle(float("nan"), vb)
+        assert "ground_truth" in str(exc_info.value)
+        assert "finite" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_inf_raises(self, reputer_with_sqe):
+        vb = _make_value_bundle(combined_value="5.0", naive_value="5.0")
+        with pytest.raises(ValueError) as exc_info:
+            await reputer_with_sqe._compute_loss_bundle(float("inf"), vb)
+        assert "ground_truth" in str(exc_info.value)
+        assert "finite" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_neg_inf_raises(self, reputer_with_sqe):
+        vb = _make_value_bundle(combined_value="5.0", naive_value="5.0")
+        with pytest.raises(ValueError) as exc_info:
+            await reputer_with_sqe._compute_loss_bundle(float("-inf"), vb)
+        assert "ground_truth" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_predicted_nan_in_combined_raises(self, reputer_with_sqe):
+        vb = _make_value_bundle(combined_value="nan", naive_value="0")
+        with pytest.raises(ValueError) as exc_info:
+            await reputer_with_sqe._compute_loss_bundle(10.0, vb)
+        assert "predicted" in str(exc_info.value)
+        assert "finite" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_predicted_inf_in_combined_raises(self, reputer_with_sqe):
+        vb = _make_value_bundle(combined_value="inf", naive_value="0")
+        with pytest.raises(ValueError) as exc_info:
+            await reputer_with_sqe._compute_loss_bundle(10.0, vb)
+        assert "predicted" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_finite_values_succeed(self, reputer_with_sqe):
+        vb = _make_value_bundle(combined_value="8.0", naive_value="9.0")
+        result = await reputer_with_sqe._compute_loss_bundle(10.0, vb)
+        assert result.combined_value == "4.0"  # (10-8)^2 = 4
+        assert result.naive_value == "1.0"  # (10-9)^2 = 1
+
+
+# ---------------------------------------------------------------------------
+# ZTAE/ZPTAE explicit configuration requirement
+# ---------------------------------------------------------------------------
+
+
+class TestRequiresExplicitLossFn:
+    """Test requires_explicit_loss_fn helper."""
+
+    @pytest.mark.parametrize("method", ["ztae", "zptae", "ZTAE", "ztae_loss", "zptae_loss"])
+    def test_ztae_zptae_require_explicit(self, method: str):
+        assert requires_explicit_loss_fn(method) is True
+
+    @pytest.mark.parametrize("method", ["sqe", "abse", "huber", "bce", "poisson"])
+    def test_other_methods_no_requirement(self, method: str):
+        assert requires_explicit_loss_fn(method) is False
+
+
+class TestMaybeAutoSelectLossFnZtaeZptae:
+    """Test that _maybe_auto_select_loss_fn raises when topic uses ztae/zptae without explicit loss_fn."""
+
+    @pytest.fixture
+    def reputer_no_loss_fn(self):
+        wallet = Mock()
+        wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
+        client = Mock()
+        return Reputer(
+            wallet=wallet,
+            client=client,
+            topic_id=1,
+            ground_truth_fn=lambda _: 10.0,
+            loss_fn=None,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("loss_method", ["ztae", "zptae", "ZTAE", "ztae_loss"])
+    async def test_ztae_zptae_without_loss_fn_raises(
+        self, reputer_no_loss_fn: Reputer, loss_method: str
+    ):
+        topic = Mock()
+        topic.loss_method = loss_method
+        reputer_no_loss_fn.client.emissions.query.get_topic = AsyncMock(
+            return_value=Mock(topic=topic)
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            await reputer_no_loss_fn._maybe_auto_select_loss_fn()
+
+        msg = str(exc_info.value)
+        assert "make_ztae_loss" in msg or "make_zptae_loss" in msg
+        assert "explicit" in msg.lower()
+        assert loss_method.lower() in msg.lower() or "ztae" in msg or "zptae" in msg
+
+    @pytest.mark.asyncio
+    async def test_ztae_with_explicit_loss_fn_succeeds(self):
+        wallet = Mock()
+        wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
+        client = Mock()
+        reputer = Reputer(
+            wallet=wallet,
+            client=client,
+            topic_id=1,
+            ground_truth_fn=lambda _: 10.0,
+            loss_fn=make_ztae_loss(std=0.02),
+        )
+        await reputer._maybe_auto_select_loss_fn()
+        assert reputer.loss_fn is not None
+
+    @pytest.mark.asyncio
+    async def test_zptae_with_explicit_loss_fn_succeeds(self):
+        wallet = Mock()
+        wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
+        client = Mock()
+        reputer = Reputer(
+            wallet=wallet,
+            client=client,
+            topic_id=1,
+            ground_truth_fn=lambda _: 10.0,
+            loss_fn=make_zptae_loss(std=0.02),
+        )
+        await reputer._maybe_auto_select_loss_fn()
+        assert reputer.loss_fn is not None


### PR DESCRIPTION
## Summary
- add finite-value guards for reputer loss inputs so `nan`/`inf` fail fast with field context
- require explicit `loss_fn` config for `ztae`/`zptae` instead of implicit defaults
- add focused regression tests for non-finite inputs and explicit loss-method requirements

## Test plan
- [x] `uv run python -m pytest tests/test_reputer_loss_safety.py tests/test_loss_methods.py -q`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens loss safety in the Reputer by rejecting non‑finite inputs and requiring an explicit loss_fn for ztae/zptae to prevent unsafe defaults. Adds targeted tests to ensure failures are clear and early.

- **Bug Fixes**
  - Reject NaN/Inf for ground_truth and predictions with clear ValueErrors.
  - Expose requires_explicit_loss_fn(loss_method) to flag methods that need custom loss.
  - Add regression tests for non‑finite inputs and explicit loss requirements.

- **Migration**
  - If a topic uses ztae or zptae, pass a custom loss_fn.
    - Example: loss_fn=make_ztae_loss(std=0.02) or loss_fn=make_zptae_loss(std=0.02).

<sup>Written for commit 5be830c9f1e7a7b0998c81c21cd2ed75b527f934. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

