### PR TITLE
[PR37] Strengthen autostake idempotence keys

### DIFF
--- a/src/allora_sdk/worker/autostake.py
+++ b/src/allora_sdk/worker/autostake.py
@@ -16,6 +16,11 @@ from allora_sdk.rpc_client.tx_manager import FeeTier
 logger = logging.getLogger("allora_sdk")
 
 
+# Composite idempotence key: (role, topic_id, target_type, target_address, block_height_tx, block_height, reward_uallo)
+# Used to deduplicate EventRewardsSettled handling across WebSocket replays and avoid double delegation.
+AutoStakeKey = tuple[str, int, str, str, int, int, int]
+
+
 class InvalidAutoStakeConfigError(Exception):
     """Raised when autostake configuration is invalid (e.g., reputer not registered, validator not found)."""
 
@@ -185,6 +190,49 @@ def compute_stake_amount_uallo(reward_uallo: int, fee_reserve_uallo: int) -> int
     return max(0, int(reward_uallo) - reserve)
 
 
+def make_autostake_key(
+    *,
+    role: AutoStakeRole,
+    topic_id: int,
+    target_type: AutoStakeTargetType,
+    target_address: str,
+    block_height: int,
+    block_height_tx: int | None,
+    reward_uallo: int,
+) -> AutoStakeKey:
+    """
+    Build a composite idempotence key for autostake deduplication.
+
+    Includes role, topic_id, target_type, target_address, block_height_tx (or 0 if absent),
+    block_height, and reward_uallo to avoid collisions across:
+    - WebSocket replay of the same event
+    - Different topics / roles / targets with same nonce and reward amount
+    """
+    block_height_tx_val = int(block_height_tx or 0)
+    return (
+        role.value,
+        topic_id,
+        target_type.value,
+        target_address,
+        block_height_tx_val,
+        block_height,
+        reward_uallo,
+    )
+
+
+def _keys_match(last_key: AutoStakeKey | tuple[int, int] | None, new_key: AutoStakeKey) -> bool:
+    """
+    Compare last and new idempotence keys for deduplication.
+
+    Supports legacy 2-tuple (block_height, reward_uallo) for backward compatibility.
+    """
+    if last_key is None:
+        return False
+    if len(last_key) == 2:
+        return (last_key[0], last_key[1]) == (new_key[5], new_key[6])
+    return last_key == new_key
+
+
 async def process_autostake_rewards_settled(
     *,
     role: AutoStakeRole,
@@ -194,13 +242,13 @@ async def process_autostake_rewards_settled(
     client: AlloraRPCClient,
     autostake: AutoStakeConfig | None,
     default_fee_tier: FeeTier,
-    last_autostake_key: tuple[int, int] | None,
-) -> tuple[int, int] | None:
+    last_autostake_key: AutoStakeKey | tuple[int, int] | None,
+) -> AutoStakeKey | None:
     """
     Shared autostake handler for Inferer/Forecaster workers.
 
     Returns:
-        The new idempotence key (nonce_block_height, reward_uallo) if we decided to process this event
+        The new composite idempotence key if we decided to process this event
         (even if the tx fails), otherwise None.
     """
 
@@ -229,8 +277,18 @@ async def process_autostake_rewards_settled(
         )
         return None
 
-    autostake_key = (int(getattr(event, "block_height", 0) or 0), reward_uallo)
-    if last_autostake_key == autostake_key:
+    block_height = int(getattr(event, "block_height", 0) or 0)
+    block_height_tx = getattr(event, "block_height_tx", None)
+    autostake_key = make_autostake_key(
+        role=role,
+        topic_id=topic_id,
+        target_type=autostake.target_type,
+        target_address=autostake.target_address,
+        block_height=block_height,
+        block_height_tx=block_height_tx,
+        reward_uallo=reward_uallo,
+    )
+    if _keys_match(last_autostake_key, autostake_key):
         logger.debug("[AUTO-STAKE] Skipping: duplicate event key=%s", autostake_key)
         return None
 

--- a/src/allora_sdk/worker/autostake.py
+++ b/src/allora_sdk/worker/autostake.py
@@ -208,7 +208,7 @@ def make_autostake_key(
     - WebSocket replay of the same event
     - Different topics / roles / targets with same nonce and reward amount
     """
-    block_height_tx_val = int(block_height_tx or 0)
+    block_height_tx_val = 0 if block_height_tx is None else int(block_height_tx)
     return (
         role.value,
         topic_id,

--- a/tests/test_autostake.py
+++ b/tests/test_autostake.py
@@ -166,6 +166,18 @@ class TestMakeAutostakeKey:
         )
         assert key[4] == 0
 
+    def test_invalid_falsy_block_height_tx_does_not_coalesce_with_none(self):
+        with pytest.raises(ValueError):
+            make_autostake_key(
+                role=AutoStakeRole.INFERER,
+                topic_id=1,
+                target_type=AutoStakeTargetType.REPUTER,
+                target_address="allo1addr",
+                block_height=100,
+                block_height_tx="",  # type: ignore[arg-type]
+                reward_uallo=200,
+            )
+
     def test_different_role_produces_different_key(self):
         base = dict(
             topic_id=1,

--- a/tests/test_autostake.py
+++ b/tests/test_autostake.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from allora_sdk.worker.autostake import (
     AutoStakeConfig,
+    AutoStakeRole,
     AutoStakeTargetType,
     extract_reward_amount_uallo,
+    make_autostake_key,
     normalize_actor_type,
+    process_autostake_rewards_settled,
 )
 
 
@@ -102,3 +105,299 @@ class TestAutoStakeConfig:
     def test_invalid_string_target_type_raises(self):
         with pytest.raises(ValueError):
             AutoStakeConfig(target_type="bogus", target_address="allo1abc")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# make_autostake_key (idempotence key construction)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeAutostakeKey:
+    def test_deterministic_for_same_inputs(self):
+        key1 = make_autostake_key(
+            role=AutoStakeRole.INFERER,
+            topic_id=42,
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1reputer",
+            block_height=1000,
+            block_height_tx=1005,
+            reward_uallo=500,
+        )
+        key2 = make_autostake_key(
+            role=AutoStakeRole.INFERER,
+            topic_id=42,
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1reputer",
+            block_height=1000,
+            block_height_tx=1005,
+            reward_uallo=500,
+        )
+        assert key1 == key2
+
+    def test_includes_all_fields(self):
+        key = make_autostake_key(
+            role=AutoStakeRole.FORECASTER,
+            topic_id=69,
+            target_type=AutoStakeTargetType.VALIDATOR,
+            target_address="allovaloper1xyz",
+            block_height=2000,
+            block_height_tx=2010,
+            reward_uallo=1000,
+        )
+        assert key == (
+            "forecaster",
+            69,
+            "validator",
+            "allovaloper1xyz",
+            2010,
+            2000,
+            1000,
+        )
+
+    def test_block_height_tx_none_becomes_zero(self):
+        key = make_autostake_key(
+            role=AutoStakeRole.INFERER,
+            topic_id=1,
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1addr",
+            block_height=100,
+            block_height_tx=None,
+            reward_uallo=200,
+        )
+        assert key[4] == 0
+
+    def test_different_role_produces_different_key(self):
+        base = dict(
+            topic_id=1,
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1addr",
+            block_height=100,
+            block_height_tx=105,
+            reward_uallo=500,
+        )
+        k1 = make_autostake_key(role=AutoStakeRole.INFERER, **base)
+        k2 = make_autostake_key(role=AutoStakeRole.FORECASTER, **base)
+        assert k1 != k2
+
+    def test_different_topic_produces_different_key(self):
+        base = dict(
+            role=AutoStakeRole.INFERER,
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1addr",
+            block_height=100,
+            block_height_tx=105,
+            reward_uallo=500,
+        )
+        k1 = make_autostake_key(topic_id=1, **base)
+        k2 = make_autostake_key(topic_id=2, **base)
+        assert k1 != k2
+
+    def test_different_block_height_tx_produces_different_key(self):
+        base = dict(
+            role=AutoStakeRole.INFERER,
+            topic_id=1,
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1addr",
+            block_height=100,
+            reward_uallo=500,
+        )
+        k1 = make_autostake_key(block_height_tx=105, **base)
+        k2 = make_autostake_key(block_height_tx=110, **base)
+        assert k1 != k2
+
+
+# ---------------------------------------------------------------------------
+# process_autostake_rewards_settled - dedupe / replay
+# ---------------------------------------------------------------------------
+
+
+def _make_rewards_settled_event(
+    *,
+    topic_id: int = 42,
+    block_height: int = 1000,
+    block_height_tx: int | None = 1005,
+    actor_type: str = "ACTOR_TYPE_INFERER_UNSPECIFIED",
+    addresses: list[str] | None = None,
+    rewards: list[str] | None = None,
+) -> Mock:
+    event = Mock()
+    event.topic_id = topic_id
+    event.block_height = block_height
+    event.block_height_tx = block_height_tx
+    event.actor_type = actor_type
+    event.addresses = addresses or ["allo1wallet"]
+    event.rewards = rewards or ["500"]
+    return event
+
+
+def _make_mock_client_delegate_success() -> Mock:
+    client = Mock()
+    pending = AsyncMock()
+    resp = Mock()
+    resp.code = 0
+    resp.raw_log = ""
+    resp.txhash = "abc123"
+    pending.wait = AsyncMock(return_value=resp)
+    client.emissions.tx.delegate_stake = AsyncMock(return_value=pending)
+    client.network = Mock()
+    client.network.fee_denom = "uallo"
+    client.staking = Mock()
+    client.staking.tx = Mock()
+    client.staking.tx.delegate = AsyncMock(return_value=pending)
+    return client
+
+
+class TestProcessAutostakeRewardsSettledDedupe:
+    """Tests for idempotence / dedupe behavior."""
+
+    @pytest.mark.asyncio
+    async def test_replay_same_event_skipped_when_last_key_matches(self):
+        event = _make_rewards_settled_event(topic_id=42, block_height=1000, rewards=["500"])
+        wallet = "allo1wallet"
+        client = _make_mock_client_delegate_success()
+        autostake = AutoStakeConfig(
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1reputer",
+        )
+        event.addresses = [wallet]
+        event.rewards = ["500"]
+
+        # First call: processes and returns key
+        result1 = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=None,
+        )
+        assert result1 is not None
+        delegate_calls = client.emissions.tx.delegate_stake.call_count
+
+        # Replay: same event with last_key = result1 → skipped
+        result2 = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=result1,
+        )
+        assert result2 is None
+        assert client.emissions.tx.delegate_stake.call_count == delegate_calls  # no extra call
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_legacy_2tuple_matches_and_skips(self):
+        """Legacy (block_height, reward_uallo) key still triggers dedupe."""
+        event = _make_rewards_settled_event(topic_id=42, block_height=2000)
+        event.rewards = ["300"]
+        wallet = "allo1wallet"
+        client = _make_mock_client_delegate_success()
+        autostake = AutoStakeConfig(
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1reputer",
+        )
+
+        # Pass legacy 2-tuple that matches (block_height=2000, reward=300)
+        result = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=(2000, 300),
+        )
+        assert result is None
+        client.emissions.tx.delegate_stake.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_different_block_height_processes(self):
+        """Different nonce/block_height is not a duplicate."""
+        wallet = "allo1wallet"
+        client = _make_mock_client_delegate_success()
+        autostake = AutoStakeConfig(
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1reputer",
+        )
+
+        event1 = _make_rewards_settled_event(block_height=1000, block_height_tx=1005)
+        event1.addresses = [wallet]
+        event1.rewards = ["500"]
+
+        result1 = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event1,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=None,
+        )
+        assert result1 is not None
+
+        event2 = _make_rewards_settled_event(block_height=1001, block_height_tx=1006)
+        event2.addresses = [wallet]
+        event2.rewards = ["600"]
+
+        result2 = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event2,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=result1,
+        )
+        assert result2 is not None
+        assert client.emissions.tx.delegate_stake.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_same_block_height_different_reward_processes(self):
+        """Same block_height but different reward amount is not a duplicate."""
+        wallet = "allo1wallet"
+        client = _make_mock_client_delegate_success()
+        autostake = AutoStakeConfig(
+            target_type=AutoStakeTargetType.REPUTER,
+            target_address="allo1reputer",
+        )
+
+        event1 = _make_rewards_settled_event(block_height=1000)
+        event1.addresses = [wallet]
+        event1.rewards = ["500"]
+
+        result1 = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event1,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=None,
+        )
+        assert result1 is not None
+
+        event2 = _make_rewards_settled_event(block_height=1000, block_height_tx=1005)
+        event2.addresses = [wallet]
+        event2.rewards = ["501"]  # different reward
+
+        result2 = await process_autostake_rewards_settled(
+            role=AutoStakeRole.INFERER,
+            event=event2,
+            topic_id=42,
+            wallet_addr=wallet,
+            client=client,
+            autostake=autostake,
+            default_fee_tier=Mock(value="PRIORITY"),
+            last_autostake_key=result1,
+        )
+        assert result2 is not None
+        assert client.emissions.tx.delegate_stake.call_count == 2


### PR DESCRIPTION
## Summary
- replace fragile nonce/reward dedupe with a composite autostake idempotence key
- preserve backward-compatible replay handling for legacy key tuples
- add collision/replay coverage in autostake tests

## Test plan
- [x] `uv run python -m pytest tests/test_autostake.py -q`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened autostake idempotence to prevent duplicate delegations on WebSocket replays using a composite key across role, topic, target, tx height, block height, and reward. Preserves compatibility with legacy (block_height, reward) keys and adds targeted replay/collision tests.

- **Bug Fixes**
  - Introduced AutoStakeKey and make_autostake_key; block_height_tx None coerced to 0.
  - Added _keys_match and updated process_autostake_rewards_settled to accept legacy 2-tuples, and to build/return the composite key.
  - Added tests for key construction, replay dedupe, and legacy back-compat.

<sup>Written for commit a0089fb415f47ace3d1c9cde6394a446ef385670. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

