### PR TITLE
[PR37] Throttle inferer sanity-check RPC usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ inference_worker = AlloraWorker.inferer(
     #     target_address="allovaloper1...validator",
     # ),
 
-    # Sanity check compares your prediction to network consensus (z-score); throttled to reduce RPC
-    # sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=60),
-    # Disable entirely: sanity_check=SanityCheckConfig(enabled=False),
+    # Optional sanity check (default: enabled, 60s throttle)
+    # sanity_check=SanityCheckConfig(enabled=False),  # disable
+    # sanity_check=SanityCheckConfig(throttle_interval_seconds=30.0),
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ More resources:
 ```python
 from allora_sdk import AlloraWorker, FeeTier, AlloraWalletConfig, AlloraNetworkConfig
 from allora_sdk.worker.autostake import AutoStakeConfig, AutoStakeTargetType
+from allora_sdk.worker import SanityCheckConfig
 
 inference_worker = AlloraWorker.inferer(
     #
@@ -149,6 +150,10 @@ inference_worker = AlloraWorker.inferer(
     #     target_type=AutoStakeTargetType.VALIDATOR,
     #     target_address="allovaloper1...validator",
     # ),
+
+    # Sanity check compares your prediction to network consensus (z-score); throttled to reduce RPC
+    # sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=60),
+    # Disable entirely: sanity_check=SanityCheckConfig(enabled=False),
 )
 ```
 

--- a/src/allora_sdk/worker/__init__.py
+++ b/src/allora_sdk/worker/__init__.py
@@ -14,6 +14,7 @@ from .autostake import (
     AutoStakeTargetType,
     InvalidAutoStakeConfigError,
 )
+from .inferer import SanityCheckConfig
 
 # Backward compatibility alias
 default_squared_error_loss = squared_error_loss
@@ -25,4 +26,5 @@ __all__ = [
     "AutoStakeConfig",
     "AutoStakeTargetType",
     "InvalidAutoStakeConfigError",
+    "SanityCheckConfig",
 ]

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -39,6 +39,10 @@ class SanityCheckConfig:
     enabled: bool = True
     throttle_interval_seconds: float = 60.0
 
+    def __post_init__(self) -> None:
+        if self.throttle_interval_seconds < 0:
+            raise ValueError("throttle_interval_seconds must be >= 0")
+
 
 TInfererRunFnResult = Union[str, float, Decimal]
 TInfererRunFn = TRunFn[TInfererRunFnResult]
@@ -242,6 +246,7 @@ class Inferer:
             )
 
             if use_cache:
+                assert cache is not None
                 inferer_values = cache[1]
             else:
                 response = await self.client.emissions.query.get_latest_network_inferences(
@@ -249,6 +254,7 @@ class Inferer:
                 )
 
                 if not response.network_inferences or not response.network_inferences.inferer_values:
+                    self._sanity_cache = (now, [])
                     return
 
                 inferer_values = []
@@ -258,8 +264,8 @@ class Inferer:
                     except (ValueError, TypeError):
                         continue
 
-                if len(inferer_values) >= 3:
-                    self._sanity_cache = (now, inferer_values)
+                # Cache all fetched values (including 0-2 values) so throttling still works.
+                self._sanity_cache = (now, inferer_values)
 
             if len(inferer_values) >= 3:
                 self._sanity_check_with_values(prediction, inferer_values)

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -1,4 +1,6 @@
 import logging
+import time
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Union
 
@@ -21,6 +23,23 @@ from allora_sdk.worker.autostake import AutoStakeConfig, AutoStakeRole, process_
 logger = logging.getLogger("allora_sdk")
 
 
+@dataclass(frozen=True)
+class SanityCheckConfig:
+    """
+    Configuration for the inferer sanity check that compares predictions against network consensus.
+
+    Uses a throttle to avoid expensive RPC on every submit: cached network inferences are reused
+    until the throttle interval elapses.
+
+    Attributes:
+        enabled: If False, sanity checks are skipped entirely.
+        throttle_interval_seconds: Minimum seconds between RPC calls; cached data is reused within this interval.
+    """
+
+    enabled: bool = True
+    throttle_interval_seconds: float = 60.0
+
+
 TInfererRunFnResult = Union[str, float, Decimal]
 TInfererRunFn = TRunFn[TInfererRunFnResult]
 
@@ -34,6 +53,7 @@ class Inferer:
         run: TInfererRunFn,
         fee_tier: FeeTier,
         autostake: AutoStakeConfig | None = None,
+        sanity_check: SanityCheckConfig | None = None,
     ):
         self.wallet = wallet
         self.client = client
@@ -41,9 +61,13 @@ class Inferer:
         self.predict_fn = run
         self.fee_tier = fee_tier
         self.autostake = autostake
+        self.sanity_check = sanity_check or SanityCheckConfig()
 
         # Simple in-memory idempotence for rewards events
         self._last_autostake_key: tuple[int, int] | None = None
+
+        # Throttle cache: (fetch_timestamp, inferer_values)
+        self._sanity_cache: tuple[float, list[float]] | None = None
 
 
     def name(self) -> str:
@@ -129,11 +153,12 @@ class Inferer:
             logger.debug(f"Prediction function failed: {err}")
             return err
 
-        # Sanity check prediction against network consensus
-        try:
-            await self._sanity_check_submission(float(prediction))
-        except (ValueError, TypeError):
-            logger.debug(f"Could not convert prediction to float for sanity check: {prediction}")
+        # Sanity check prediction against network consensus (throttled; see SanityCheckConfig)
+        if self.sanity_check.enabled:
+            try:
+                await self._sanity_check_submission(float(prediction))
+            except (ValueError, TypeError):
+                logger.debug(f"Could not convert prediction to float for sanity check: {prediction}")
 
         try:
             pending = await self.client.emissions.tx.insert_worker_payload(
@@ -168,9 +193,38 @@ class Inferer:
             return err
 
 
+    def _sanity_check_with_values(self, prediction: float, inferer_values: list[float]) -> None:
+        """Apply z-score analysis using pre-extracted inferer values."""
+        if len(inferer_values) < 3:
+            return
+
+        mean = sum(inferer_values) / len(inferer_values)
+        variance = sum((x - mean) ** 2 for x in inferer_values) / len(inferer_values)
+        std_dev = variance ** 0.5
+
+        if std_dev == 0:
+            return
+
+        z_score = abs((prediction - mean) / std_dev)
+
+        if z_score > 3.0:
+            logger.warning(
+                f"⚠️⚠️⚠️  SANITY CHECK WARNING: Your prediction ({prediction:.6f}) is {z_score:.1f} "
+                f"standard deviations from the network consensus (mean: {mean:.6f}, std: {std_dev:.6f}). "
+                f"Please verify you're predicting the correct target variable and using the right units."
+            )
+        elif z_score > 2.0:
+            logger.info(
+                f"ℹ️  NOTICE: Your prediction ({prediction:.6f}) is {z_score:.1f} standard deviations "
+                f"from consensus (mean: {mean:.6f}). This may indicate a contrarian view or potential issue."
+            )
+
     async def _sanity_check_submission(self, prediction: float) -> None:
         """
         Sanity check user's prediction against network consensus using z-score analysis.
+
+        Uses a throttle: network inferences are cached and reused until
+        throttle_interval_seconds elapses, reducing RPC overhead on rapid submissions.
 
         Warns the user if their prediction is suspiciously far from the consensus,
         which could indicate they're predicting the wrong target variable or using
@@ -180,51 +234,35 @@ class Inferer:
             prediction: User's prediction value to check
         """
         try:
-            # Query latest network inferences to get consensus
-            response = await self.client.emissions.query.get_latest_network_inferences(
-                GetLatestNetworkInferencesRequest(topic_id=self.topic_id)
+            now = time.monotonic()
+            cache = self._sanity_cache
+            use_cache = (
+                cache is not None
+                and (now - cache[0]) < self.sanity_check.throttle_interval_seconds
             )
 
-            if not response.network_inferences or not response.network_inferences.inferer_values:
-                # Not enough data to perform sanity check
-                return
-
-            # Extract individual inferer values
-            inferer_values = []
-            for inferer in response.network_inferences.inferer_values:
-                try:
-                    inferer_values.append(float(inferer.value))
-                except (ValueError, TypeError):
-                    continue
-
-            if len(inferer_values) < 3:
-                # Need at least 3 values for meaningful statistics
-                return
-
-            # Calculate mean and standard deviation
-            mean = sum(inferer_values) / len(inferer_values)
-            variance = sum((x - mean) ** 2 for x in inferer_values) / len(inferer_values)
-            std_dev = variance ** 0.5
-
-            if std_dev == 0:
-                # All predictions are identical, can't calculate z-score
-                return
-
-            # Calculate z-score
-            z_score = abs((prediction - mean) / std_dev)
-
-            # Warn if prediction is more than 3 standard deviations away
-            if z_score > 3.0:
-                logger.warning(
-                    f"⚠️⚠️⚠️  SANITY CHECK WARNING: Your prediction ({prediction:.6f}) is {z_score:.1f} "
-                    f"standard deviations from the network consensus (mean: {mean:.6f}, std: {std_dev:.6f}). "
-                    f"Please verify you're predicting the correct target variable and using the right units."
+            if use_cache:
+                inferer_values = cache[1]
+            else:
+                response = await self.client.emissions.query.get_latest_network_inferences(
+                    GetLatestNetworkInferencesRequest(topic_id=self.topic_id)
                 )
-            elif z_score > 2.0:
-                logger.info(
-                    f"ℹ️  NOTICE: Your prediction ({prediction:.6f}) is {z_score:.1f} standard deviations "
-                    f"from consensus (mean: {mean:.6f}). This may indicate a contrarian view or potential issue."
-                )
+
+                if not response.network_inferences or not response.network_inferences.inferer_values:
+                    return
+
+                inferer_values = []
+                for inferer in response.network_inferences.inferer_values:
+                    try:
+                        inferer_values.append(float(inferer.value))
+                    except (ValueError, TypeError):
+                        continue
+
+                if len(inferer_values) >= 3:
+                    self._sanity_cache = (now, inferer_values)
+
+            if len(inferer_values) >= 3:
+                self._sanity_check_with_values(prediction, inferer_values)
 
         except Exception as e:
             # Don't let sanity check failures block submissions

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -35,7 +35,7 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
 from allora_sdk.utils import Context, TimestampOrderedSet, format_allo_from_uallo
 from allora_sdk.logging_config import setup_sdk_logging
 from allora_sdk.worker.forecaster import Forecaster, TForecasterRunFn, TForecasterRunFnResult
-from allora_sdk.worker.inferer import Inferer, TInfererRunFn, TInfererRunFnResult
+from allora_sdk.worker.inferer import Inferer, SanityCheckConfig, TInfererRunFn, TInfererRunFnResult
 from allora_sdk.worker.reputer import GroundTruthFn, LossFn, Reputer
 from allora_sdk.worker.autostake import AutoStakeConfig
 from allora_sdk.worker.types import (
@@ -82,6 +82,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         polling_interval: int = 120,
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
         autostake: AutoStakeConfig | None = None,
+        sanity_check: SanityCheckConfig | None = None,
         debug: bool = False,
     ):
         """
@@ -96,6 +97,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
             autostake: Optional autostake config to stake this worker's rewards to a reputer or validator
+            sanity_check: Optional sanity check config; defaults to enabled with 60s throttle interval
             debug: Enable debug logging
 
         Returns:
@@ -115,6 +117,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
                 run=run,
                 client=client,
                 autostake=autostake,
+                sanity_check=sanity_check,
             ),
             address=str(wallet_initialized.address()),
             client=client,

--- a/tests/test_inferer_sanity_check.py
+++ b/tests/test_inferer_sanity_check.py
@@ -1,11 +1,5 @@
 """
 Tests for inferer sanity-check throttle behavior and configuration.
-
-Verifies that:
-- Sanity checks can be disabled via config
-- RPC calls are throttled when within interval
-- Fresh RPC is made when throttle expires
-- Default config preserves safety intent
 """
 
 from __future__ import annotations
@@ -60,18 +54,22 @@ def _make_inferer(
 
 
 class TestSanityCheckConfig:
-    def test_default_enabled(self):
+    def test_default_enabled(self) -> None:
         cfg = SanityCheckConfig()
         assert cfg.enabled is True
         assert cfg.throttle_interval_seconds == 60.0
 
-    def test_explicit_disabled(self):
+    def test_explicit_disabled(self) -> None:
         cfg = SanityCheckConfig(enabled=False)
         assert cfg.enabled is False
 
-    def test_custom_interval(self):
+    def test_custom_interval(self) -> None:
         cfg = SanityCheckConfig(throttle_interval_seconds=30.5)
         assert cfg.throttle_interval_seconds == 30.5
+
+    def test_negative_interval_rejected(self) -> None:
+        with pytest.raises(ValueError, match="throttle_interval_seconds must be >= 0"):
+            SanityCheckConfig(throttle_interval_seconds=-1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -175,3 +173,57 @@ class TestSanityCheckThrottle:
             await inferer.submit(nonce=2, account_seq=1)
 
         assert client.emissions.query.get_latest_network_inferences.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_applies_when_fewer_than_three_values(self) -> None:
+        """Topics with only 1-2 inferers still benefit from throttle cache."""
+        wallet = MagicMock()
+        client = _make_mock_client()
+        client.emissions.query.get_latest_network_inferences = AsyncMock(
+            return_value=_make_inferer_values_response(100.0, 101.0)
+        )
+        pending = MagicMock()
+        pending.wait = AsyncMock(return_value=MagicMock())
+        client.emissions.tx.insert_worker_payload = AsyncMock(return_value=pending)
+
+        inferer = _make_inferer(
+            wallet,
+            client,
+            sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=10.0),
+        )
+
+        with patch("allora_sdk.worker.inferer.time") as mock_time:
+            mock_time.monotonic.return_value = 2000.0
+            await inferer.submit(nonce=1, account_seq=0)
+
+            mock_time.monotonic.return_value = 2005.0
+            await inferer.submit(nonce=2, account_seq=1)
+
+        assert client.emissions.query.get_latest_network_inferences.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_applies_when_response_has_no_inferences(self) -> None:
+        """Empty/None inference responses are cached to avoid repeated RPC spam."""
+        wallet = MagicMock()
+        client = _make_mock_client()
+        response = MagicMock()
+        response.network_inferences = None
+        client.emissions.query.get_latest_network_inferences = AsyncMock(return_value=response)
+        pending = MagicMock()
+        pending.wait = AsyncMock(return_value=MagicMock())
+        client.emissions.tx.insert_worker_payload = AsyncMock(return_value=pending)
+
+        inferer = _make_inferer(
+            wallet,
+            client,
+            sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=10.0),
+        )
+
+        with patch("allora_sdk.worker.inferer.time") as mock_time:
+            mock_time.monotonic.return_value = 3000.0
+            await inferer.submit(nonce=1, account_seq=0)
+
+            mock_time.monotonic.return_value = 3005.0
+            await inferer.submit(nonce=2, account_seq=1)
+
+        assert client.emissions.query.get_latest_network_inferences.call_count == 1

--- a/tests/test_inferer_sanity_check.py
+++ b/tests/test_inferer_sanity_check.py
@@ -1,0 +1,177 @@
+"""
+Tests for inferer sanity-check throttle behavior and configuration.
+
+Verifies that:
+- Sanity checks can be disabled via config
+- RPC calls are throttled when within interval
+- Fresh RPC is made when throttle expires
+- Default config preserves safety intent
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from allora_sdk.rpc_client.tx_manager import FeeTier
+from allora_sdk.worker.inferer import Inferer, SanityCheckConfig
+
+
+def _make_mock_client() -> MagicMock:
+    """Create a mock AlloraRPCClient with emissions.query stub."""
+    client = MagicMock()
+    client.emissions = MagicMock()
+    client.emissions.query = MagicMock()
+    client.emissions.tx = MagicMock()
+    return client
+
+
+def _make_inferer_values_response(*values: float):
+    """Build mock response with inferer values (need >= 3 for sanity check)."""
+    inferer_values = [MagicMock(value=str(v)) for v in values]
+    network_inferences = MagicMock()
+    network_inferences.inferer_values = inferer_values
+    response = MagicMock()
+    response.network_inferences = network_inferences
+    return response
+
+
+def _make_inferer(
+    wallet: MagicMock,
+    client: MagicMock,
+    topic_id: int = 69,
+    sanity_check: SanityCheckConfig | None = None,
+) -> Inferer:
+    return Inferer(
+        wallet=wallet,
+        client=client,
+        topic_id=topic_id,
+        run=lambda n: 100.0,
+        fee_tier=FeeTier.STANDARD,
+        autostake=None,
+        sanity_check=sanity_check,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SanityCheckConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSanityCheckConfig:
+    def test_default_enabled(self):
+        cfg = SanityCheckConfig()
+        assert cfg.enabled is True
+        assert cfg.throttle_interval_seconds == 60.0
+
+    def test_explicit_disabled(self):
+        cfg = SanityCheckConfig(enabled=False)
+        assert cfg.enabled is False
+
+    def test_custom_interval(self):
+        cfg = SanityCheckConfig(throttle_interval_seconds=30.5)
+        assert cfg.throttle_interval_seconds == 30.5
+
+
+# ---------------------------------------------------------------------------
+# Sanity check disabled - no RPC
+# ---------------------------------------------------------------------------
+
+
+class TestSanityCheckDisabled:
+    @pytest.mark.asyncio
+    async def test_disabled_skips_rpc(self):
+        """When sanity_check.enabled=False, get_latest_network_inferences is never called."""
+        wallet = MagicMock()
+        client = _make_mock_client()
+        client.emissions.tx.insert_worker_payload = AsyncMock(return_value=MagicMock(wait=AsyncMock()))
+        inferer = _make_inferer(wallet, client, sanity_check=SanityCheckConfig(enabled=False))
+
+        await inferer.submit(nonce=1, account_seq=0)
+        await inferer.submit(nonce=2, account_seq=1)
+
+        client.emissions.query.get_latest_network_inferences.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Throttle - cache used within interval
+# ---------------------------------------------------------------------------
+
+
+class TestSanityCheckThrottle:
+    @pytest.mark.asyncio
+    async def test_first_submit_triggers_rpc(self):
+        """First submission with sanity check enabled triggers one RPC."""
+        wallet = MagicMock()
+        client = _make_mock_client()
+        client.emissions.query.get_latest_network_inferences = AsyncMock(
+            return_value=_make_inferer_values_response(100.0, 101.0, 102.0)
+        )
+        pending = MagicMock()
+        pending.wait = AsyncMock(return_value=MagicMock())
+        client.emissions.tx.insert_worker_payload = AsyncMock(return_value=pending)
+
+        inferer = _make_inferer(
+            wallet,
+            client,
+            sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=10.0),
+        )
+
+        await inferer.submit(nonce=1, account_seq=0)
+
+        assert client.emissions.query.get_latest_network_inferences.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_second_submit_within_interval_uses_cache(self):
+        """Second submission within throttle interval does NOT trigger new RPC."""
+        wallet = MagicMock()
+        client = _make_mock_client()
+        client.emissions.query.get_latest_network_inferences = AsyncMock(
+            return_value=_make_inferer_values_response(100.0, 101.0, 102.0)
+        )
+        pending = MagicMock()
+        pending.wait = AsyncMock(return_value=MagicMock())
+        client.emissions.tx.insert_worker_payload = AsyncMock(return_value=pending)
+
+        inferer = _make_inferer(
+            wallet,
+            client,
+            sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=10.0),
+        )
+
+        with patch("allora_sdk.worker.inferer.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            await inferer.submit(nonce=1, account_seq=0)
+
+            mock_time.monotonic.return_value = 1005.0  # 5s later, still within 10s
+            await inferer.submit(nonce=2, account_seq=1)
+
+        assert client.emissions.query.get_latest_network_inferences.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_submit_after_interval_expires_triggers_new_rpc(self):
+        """When throttle interval expires, a new RPC is made."""
+        wallet = MagicMock()
+        client = _make_mock_client()
+        client.emissions.query.get_latest_network_inferences = AsyncMock(
+            return_value=_make_inferer_values_response(100.0, 101.0, 102.0)
+        )
+        pending = MagicMock()
+        pending.wait = AsyncMock(return_value=MagicMock())
+        client.emissions.tx.insert_worker_payload = AsyncMock(return_value=pending)
+
+        inferer = _make_inferer(
+            wallet,
+            client,
+            sanity_check=SanityCheckConfig(enabled=True, throttle_interval_seconds=10.0),
+        )
+
+        with patch("allora_sdk.worker.inferer.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            await inferer.submit(nonce=1, account_seq=0)
+
+            mock_time.monotonic.return_value = 1011.0  # 11s later, interval expired
+            await inferer.submit(nonce=2, account_seq=1)
+
+        assert client.emissions.query.get_latest_network_inferences.call_count == 2


### PR DESCRIPTION
## Summary
- add `SanityCheckConfig` to control inferer sanity-check enablement and throttle interval
- cache network inferer values between submissions to reduce repeated RPC calls
- wire config through `AlloraWorker.inferer`, document usage, and add sanity-check tests

## Test plan
- [x] `PYTHONPATH=src /Users/foobar/workspace-allora/allora-sdk-py-2/.tox/3.13/bin/python -m pytest tests/test_inferer_sanity_check.py tests/test_autostake.py -q`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle the inferer sanity-check RPC by caching network inferences and expose a simple SanityCheckConfig to control enablement and interval. Cache applies to sparse or empty consensus responses to avoid duplicate RPC calls during frequent submissions.

- **New Features**
  - Added SanityCheckConfig (enabled, throttle_interval_seconds; default 60s) with non-negative interval validation. Wired into AlloraWorker.inferer and exported.
  - Throttled consensus fetch with an in-memory cache; reuses values within the interval and never blocks submissions on errors.
  - Z-score sanity check uses cached values; logs notice (>2σ) and warning (>3σ). README shows config examples; tests cover disabled mode, throttling, interval expiry, and sparse/empty responses.

- **Bug Fixes**
  - Cache now persists for 0–2 inferer values or no-inference responses, preventing repeated RPC calls within the throttle window.

<sup>Written for commit f7ba88cf2d25427a42bdd07152d5cc3878fc2a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

