### PR TITLE
Initial version of Tx Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ inference_worker = AlloraWorker.inferer(
 
 Low-level blockchain client for advanced users. Supports queries, transactions, and WebSocket subscriptions.
 
+For full module-level reference documentation (architecture, configuration, queries, transactions, events, and queue usage), see [`src/allora_sdk/rpc_client/README.md`](src/allora_sdk/rpc_client/README.md).
+
 ### Basic Usage
 
 Initialization is very flexible and straightforward.  The client can be initialized with:

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,8 +1,21 @@
-from .worker import AlloraWorker
-from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig, TxManager, FeeTier
-from .api_client import AlloraAPIClient
-from .logging_config import setup_sdk_logging
-from cosmpy.aerial.wallet import LocalWallet, PrivateKey
+"""Top-level public exports for the Allora SDK.
+
+This module uses lazy attribute loading so importing lightweight surfaces
+(`allora_sdk.api_client`) does not require heavyweight RPC/protobuf modules.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cosmpy.aerial.wallet import LocalWallet, PrivateKey
+
+    from .api_client import AlloraAPIClient
+    from .logging_config import setup_sdk_logging
+    from .rpc_client import AlloraNetworkConfig, AlloraRPCClient, AlloraWalletConfig, FeeTier, TxManager
+    from .worker import AlloraWorker
 
 __all__ = [
     "AlloraWorker",
@@ -16,3 +29,19 @@ __all__ = [
     "LocalWallet",
     "PrivateKey",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "AlloraWorker":
+        return import_module(".worker", __name__).AlloraWorker
+    if name in {"AlloraRPCClient", "AlloraNetworkConfig", "AlloraWalletConfig", "TxManager", "FeeTier"}:
+        module = import_module(".rpc_client", __name__)
+        return getattr(module, name)
+    if name == "AlloraAPIClient":
+        return import_module(".api_client", __name__).AlloraAPIClient
+    if name == "setup_sdk_logging":
+        return import_module(".logging_config", __name__).setup_sdk_logging
+    if name in {"LocalWallet", "PrivateKey"}:
+        module = import_module("cosmpy.aerial.wallet")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -33,15 +33,25 @@ __all__ = [
 
 def __getattr__(name: str) -> Any:
     if name == "AlloraWorker":
-        return import_module(".worker", __name__).AlloraWorker
+        value = import_module(".worker", __name__).AlloraWorker
+        globals()[name] = value
+        return value
     if name in {"AlloraRPCClient", "AlloraNetworkConfig", "AlloraWalletConfig", "TxManager", "FeeTier"}:
         module = import_module(".rpc_client", __name__)
-        return getattr(module, name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
     if name == "AlloraAPIClient":
-        return import_module(".api_client", __name__).AlloraAPIClient
+        value = import_module(".api_client", __name__).AlloraAPIClient
+        globals()[name] = value
+        return value
     if name == "setup_sdk_logging":
-        return import_module(".logging_config", __name__).setup_sdk_logging
+        value = import_module(".logging_config", __name__).setup_sdk_logging
+        globals()[name] = value
+        return value
     if name in {"LocalWallet", "PrivateKey"}:
         module = import_module("cosmpy.aerial.wallet")
-        return getattr(module, name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/allora_sdk/api_client/client.py
+++ b/src/allora_sdk/api_client/client.py
@@ -1,7 +1,7 @@
 import pprint
 import aiohttp
 from enum import Enum
-from typing import List, Optional, Protocol, TypeVar, Generic, Any, runtime_checkable
+from typing import Dict, List, Optional, Protocol, TypeVar, Generic, Any, runtime_checkable
 from pydantic import BaseModel, Field
 
 
@@ -81,6 +81,16 @@ class AlloraAPIClient:
         self.base_api_url = base_api_url
         self.fetcher = fetcher
 
+    def _build_headers(self) -> Dict[str, str]:
+        """Build request headers and include API key only when configured."""
+        headers: Dict[str, str] = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+        return headers
+
     async def get_all_topics(self) -> List[Topic]:
         """
         Fetches all available topics from the Allora API.
@@ -149,11 +159,7 @@ class AlloraAPIClient:
         :raises: requests.RequestException if the API request fails
         """
         url = self.get_request_url(endpoint)
-        headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "x-api-key": self.api_key,
-        }
+        headers = self._build_headers()
         response_data = await self.fetcher.fetch(url, headers)
 
         pprint.pprint(response_data)

--- a/src/allora_sdk/rpc_client/README.md
+++ b/src/allora_sdk/rpc_client/README.md
@@ -1,0 +1,388 @@
+# `allora_sdk.rpc_client`
+
+Low-level asynchronous client package for interacting with Allora chain RPC surfaces:
+
+- queries
+- transactions
+- WebSocket event subscriptions
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Configuration](#configuration)
+- [Initialization Patterns](#initialization-patterns)
+- [Module Capability Reference](#module-capability-reference)
+- [Query Usage](#query-usage)
+- [Transaction Usage](#transaction-usage)
+- [Event Subscription Usage](#event-subscription-usage)
+- [Transaction Queue Usage](#transaction-queue-usage)
+- [Error Handling Reference](#error-handling-reference)
+- [Troubleshooting](#troubleshooting)
+- [Package Structure](#package-structure)
+
+## Overview
+
+`rpc_client` centers around `AlloraRPCClient` in `client.py`. It composes module clients (`auth`, `bank`, `emissions`, `tx`, `mint`, `feemarket`, `tendermint`) and optionally provides:
+
+- transaction submission via `TxManager`
+- event subscriptions via `AlloraWebsocketSubscriber`
+
+The package supports both gRPC and Cosmos-LCD REST transports, selected from the configured RPC URL scheme.
+
+## Architecture
+
+### Core Composition
+
+- `AlloraRPCClient` creates query clients for each module.
+- If wallet credentials are configured, it creates `TxManager` and injects tx-capable wrappers.
+- If `websocket_url` is configured, it creates `AlloraWebsocketSubscriber`.
+
+### Transport Selection
+
+`AlloraRPCClient` parses `AlloraNetworkConfig.url`:
+
+- `grpc+http(s)://...` -> gRPC stubs
+- `rest+http(s)://...` -> REST query/service clients
+
+This keeps module APIs stable while allowing either wire protocol.
+
+### Type Model
+
+- Request/response types come from generated protobuf classes under `allora_sdk.rpc_client.protos`.
+- REST and gRPC clients follow interface-compatible query/service shapes in `allora_sdk.rpc_client.rest`.
+
+## Configuration
+
+### `AlloraWalletConfig`
+
+Defined in `config.py`.
+
+At least one of these must be provided:
+
+- `private_key`
+- `mnemonic`
+- `mnemonic_file`
+- `wallet` (`LocalWallet`)
+
+Optional:
+
+- `prefix` (default `allo`)
+
+Environment loader:
+
+- `AlloraWalletConfig.from_env()`
+- reads `PRIVATE_KEY`, `MNEMONIC`, `MNEMONIC_FILE`, `ADDRESS_PREFIX` (with optional prefix override)
+
+### `AlloraNetworkConfig`
+
+Defined in `config.py`.
+
+Important fields:
+
+- `chain_id`
+- `url`
+- `websocket_url`
+- `fee_denom`
+- `fee_minimum_gas_price`
+- `faucet_url`
+- `use_dynamic_gas_price`
+- `gas_price_cache_ttl_secs`
+- `congestion_aware_fees`
+
+Preset constructors:
+
+- `AlloraNetworkConfig.testnet()`
+- `AlloraNetworkConfig.mainnet()`
+- `AlloraNetworkConfig.local()`
+
+Environment loader:
+
+- `AlloraNetworkConfig.from_env()`
+- reads `CHAIN_ID`, `RPC_ENDPOINT`, `WEBSOCKET_ENDPOINT`, `FAUCET_URL`, `FEE_DENOM`, `FEE_MIN_GAS_PRICE` (with optional prefix override)
+
+## Initialization Patterns
+
+```python
+from allora_sdk import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig
+
+# 1) Preset network
+client = AlloraRPCClient.testnet()
+
+# 2) Preset network with wallet (tx-enabled)
+client = AlloraRPCClient.mainnet(
+    wallet=AlloraWalletConfig(mnemonic="...")
+)
+
+# 3) Fully custom network config
+client = AlloraRPCClient(
+    wallet=AlloraWalletConfig(private_key="..."),
+    network=AlloraNetworkConfig(
+        chain_id="allora-testnet-1",
+        url="grpc+https://allora-grpc.testnet.allora.network:443",
+        websocket_url="wss://allora-rpc.testnet.allora.network/websocket",
+    ),
+)
+
+# 4) Environment-driven setup
+client = AlloraRPCClient.from_env()
+```
+
+Call `await client.close()` when done to stop event loops and close transport resources.
+
+## Module Capability Reference
+
+### `client.auth`
+
+- File: `client_auth.py`
+- `query`: auth query service
+- `tx`: placeholder wrapper (`AuthTxs`) for symmetry
+
+### `client.bank`
+
+- File: `client_bank.py`
+- `query`: bank query service
+- `tx.send(outputs, from_addr=None, fee_tier=..., gas_limit=None, simulate=False)`
+
+`simulate=True` returns estimated gas (`int`), otherwise returns `PendingTx`.
+
+### `client.emissions`
+
+- File: `client_emissions.py`
+- `query`: emissions query service
+- `tx` methods:
+  - `register(...)`
+  - `insert_worker_payload(...)`
+  - `delegate_stake(...)`
+  - `create_topic(...)`
+  - `fund_topic(...)`
+  - `bulk_add_to_topic_worker_whitelist(...)`
+  - `bulk_add_to_topic_reputer_whitelist(...)`
+
+Each method supports `simulate=True` and fee tier selection.
+
+### `client.tx`
+
+- File: `client_tx.py`
+- `query`: tx service (read tx status/details, simulate, broadcast)
+- `tx`: placeholder wrapper (`TxTxs`) for symmetry
+
+### `client.tendermint`
+
+- File: `client_tendermint.py`
+- `query`: tendermint service
+- `tx`: placeholder wrapper (`TendermintTxs`) for symmetry
+
+### `client.mint`
+
+- File: `client_mint.py`
+- `query`: mint query service
+- no transaction wrapper exposed in this module
+
+### `client.feemarket`
+
+- File: `client_feemarket.py`
+- `query`: feemarket query service (`gas_price`, `state`, `params`, etc.)
+- `tx`: placeholder wrapper (`FeemarketTxs`) for symmetry
+
+## Query Usage
+
+Query clients are exposed as `client.<module>.query` and accept protobuf request objects.
+
+```python
+from allora_sdk import AlloraRPCClient
+from allora_sdk.rpc_client.protos.cosmos.bank.v1beta1 import QueryBalanceRequest
+
+client = AlloraRPCClient.testnet()
+balance = await client.bank.query.balance(
+    QueryBalanceRequest(address=client.address, denom="uallo")
+)
+```
+
+The same pattern applies to emissions, tx, tendermint, auth, mint, and feemarket modules.
+
+## Transaction Usage
+
+### Module-Level Transactions
+
+The preferred path is module wrappers such as `client.bank.tx.send(...)` and `client.emissions.tx.*(...)`.
+
+### `TxManager`
+
+`tx_manager.py` contains the lower-level transaction engine used by wrappers:
+
+- `submit_transaction(...)` -> returns awaitable `PendingTx`
+- `simulate_transaction(...)` -> returns gas estimate
+- `wait_for_tx(...)` -> polls for inclusion
+
+`PendingTx` tracks attempt metadata:
+
+- `last_tx_hash`
+- `last_gas_limit`
+- `last_fee`
+- `attempt`
+
+### Fee Behavior
+
+- `FeeTier`: `ECO`, `STANDARD`, `PRIORITY`
+- gas price may be dynamic through feemarket queries
+- optional congestion multiplier support
+- fallback to static network config gas price when needed
+
+### Example
+
+```python
+from allora_sdk.rpc_client.tx_manager import FeeTier
+
+pending = await client.bank.tx.send(
+    outputs=[...],
+    fee_tier=FeeTier.STANDARD,
+)
+result = await pending
+```
+
+## Event Subscription Usage
+
+Event APIs are in `client_websocket_events.py`, exposed as `client.events` when `websocket_url` is configured.
+
+### Generic Subscriptions
+
+- `subscribe(event_filter, callback)`
+- `subscribe_to_new_blocks(callback)`
+- `subscribe_to_transactions(callback)`
+- `subscribe_to_address_activity(address, callback)`
+- `unsubscribe(subscription_id)`
+
+### Targeted New Block Event Subscriptions
+
+- `subscribe_new_block_events(event_name, conditions, callback)` for untyped events
+- `subscribe_new_block_events_typed(event_class, conditions, callback)` for typed protobuf events
+
+Supporting types:
+
+- `EventFilter`
+- `EventAttributeCondition`
+
+### Typed Event Marshaling
+
+`event_utils.py` provides:
+
+- `EventRegistry`: event type -> protobuf class mapping
+- `EventMarshaler`: JSON event attributes -> typed protobuf instances
+
+## Transaction Queue Usage
+
+`tx_queue.py` provides a generic scheduler for transaction-like work.
+
+### Core Features
+
+- priority + deadline scheduling
+- per-account sequential execution
+- sequence cache with invalidation/refetch
+- retry/backoff with error classification
+- awaitable pending handles
+
+### Main Interfaces
+
+- `TxQueueAdapter`
+  - `fetch_sequence(account_id)`
+  - `submit(payload, sequence)`
+  - `classify_error(err)`
+  - `is_timeout(err)`
+- `TransactionQueue`
+- `PendingQueueTx`
+
+### Ordering
+
+1. Earliest deadline first
+2. Higher priority first
+3. FIFO for equal keys
+
+### Queue Lifecycle
+
+1. Instantiate queue with adapter
+2. `await queue.start()`
+3. `handle = await queue.enqueue(...)`
+4. `result = await handle`
+5. `await queue.stop(cancel_pending=...)`
+
+### Minimal Adapter Example
+
+```python
+from datetime import datetime, timedelta
+from typing import Optional
+
+from allora_sdk.rpc_client.tx_queue import ErrorClassification, TransactionQueue, TxQueueAdapter
+
+
+class Adapter(TxQueueAdapter[dict, str]):
+    async def fetch_sequence(self, account_id: str) -> int:
+        return 0
+
+    async def submit(self, payload: dict, sequence: Optional[int]) -> str:
+        return f"ok:{payload['id']}:{sequence}"
+
+    def classify_error(self, err: Exception) -> ErrorClassification:
+        return ErrorClassification.FATAL
+
+    def is_timeout(self, err: Exception) -> bool:
+        return False
+
+
+async def run() -> None:
+    queue = TransactionQueue[dict, str](Adapter())
+    await queue.start()
+    pending = await queue.enqueue(
+        request_id="req-1",
+        account_id="allo1...",
+        payload={"id": "tx-1"},
+        priority=50,
+        deadline_at=datetime.now() + timedelta(seconds=20),
+    )
+    _ = await pending
+    await queue.stop(cancel_pending=False)
+```
+
+## Error Handling Reference
+
+### `tx_manager.py` Errors
+
+- `TxError`
+- `InsufficientBalanceError`
+- `OutOfGasError`
+- `InsufficientFeesError`
+- `AccountSequenceMismatchError`
+- `TxNotFoundError`
+- `TxTimeoutError`
+
+### `tx_queue.py` Errors
+
+- `TxQueueNotStartedError`
+- `TxQueueStoppedError`
+- `TxDeadlineExceededError`
+- `TxRetryExhaustedError`
+
+Queue adapter fatal errors are surfaced directly.
+
+## Troubleshooting
+
+- **Missing generated protobuf modules**
+  - Ensure code generation/dev setup has run before using direct protobuf imports.
+- **`client.events` unavailable**
+  - Set `websocket_url` in `AlloraNetworkConfig`.
+- **Transaction methods unavailable**
+  - Initialize `AlloraRPCClient` with wallet credentials so `TxManager` is created.
+- **Unexpected fee behavior**
+  - Check `use_dynamic_gas_price`, `congestion_aware_fees`, and `fee_minimum_gas_price`.
+
+## Package Structure
+
+- `client.py`: top-level composition (`AlloraRPCClient`)
+- `config.py`: network/wallet config
+- `tx_manager.py`: transaction engine
+- `tx_queue.py`: generic queue
+- `client_auth.py`, `client_bank.py`, `client_emissions.py`, `client_tx.py`, `client_tendermint.py`, `client_mint.py`, `client_feemarket.py`: module wrappers
+- `client_websocket_events.py`: subscription runtime
+- `event_utils.py`: typed event discovery/marshaling
+- `wallet.py`: wallet utility helpers
+

--- a/src/allora_sdk/rpc_client/README.md
+++ b/src/allora_sdk/rpc_client/README.md
@@ -220,6 +220,9 @@ The preferred path is module wrappers such as `client.bank.tx.send(...)` and `cl
 - `use_queue=True` enables scheduling through `TransactionQueue`
 - `queue_priority` controls relative urgency among queued items
 - `queue_deadline_at` allows deadline-aware dispatch/fail-fast behavior
+- queue retries preserve legacy retry tuning:
+  - gas multiplier increases per retry attempt
+  - insufficient-fee retries invalidate gas-price cache and raise fee multiplier
 
 `PendingTx` tracks attempt metadata:
 
@@ -331,6 +334,7 @@ The queue can be used without replacing existing direct submission paths.
 - Worker/reputer emissions paths expose the same queue controls:
   - `insert_worker_payload(..., use_queue=True, queue_priority=..., queue_deadline_at=...)`
   - `delegate_stake(..., use_queue=True, queue_priority=..., queue_deadline_at=...)`
+- Queue-enabled methods return an awaitable transaction handle (compatible with `await handle` and `await handle.wait()` patterns).
 
 ### Minimal Adapter Example
 

--- a/src/allora_sdk/rpc_client/README.md
+++ b/src/allora_sdk/rpc_client/README.md
@@ -215,6 +215,12 @@ The preferred path is module wrappers such as `client.bank.tx.send(...)` and `cl
 - `simulate_transaction(...)` -> returns gas estimate
 - `wait_for_tx(...)` -> polls for inclusion
 
+`submit_transaction(...)` also supports an opt-in queue-backed mode:
+
+- `use_queue=True` enables scheduling through `TransactionQueue`
+- `queue_priority` controls relative urgency among queued items
+- `queue_deadline_at` allows deadline-aware dispatch/fail-fast behavior
+
 `PendingTx` tracks attempt metadata:
 
 - `last_tx_hash`
@@ -239,6 +245,16 @@ pending = await client.bank.tx.send(
     fee_tier=FeeTier.STANDARD,
 )
 result = await pending
+
+# Optional queue-backed submission at lower level
+queued = await client.tx_manager.submit_transaction(
+    type_url="/emissions.v9.InsertWorkerPayloadRequest",
+    msgs=[...],
+    fee_tier=FeeTier.PRIORITY,
+    use_queue=True,
+    queue_priority=80,
+)
+queued_result = await queued
 ```
 
 ## Event Subscription Usage
@@ -305,6 +321,16 @@ Supporting types:
 3. `handle = await queue.enqueue(...)`
 4. `result = await handle`
 5. `await queue.stop(cancel_pending=...)`
+
+### Queue Through `TxManager`
+
+The queue can be used without replacing existing direct submission paths.
+
+- Existing `submit_transaction(...)` behavior remains unchanged by default.
+- Set `use_queue=True` only for flows that benefit from queueing.
+- Worker/reputer emissions paths expose the same queue controls:
+  - `insert_worker_payload(..., use_queue=True, queue_priority=..., queue_deadline_at=...)`
+  - `delegate_stake(..., use_queue=True, queue_priority=..., queue_deadline_at=...)`
 
 ### Minimal Adapter Example
 

--- a/src/allora_sdk/rpc_client/__init__.py
+++ b/src/allora_sdk/rpc_client/__init__.py
@@ -1,6 +1,14 @@
-from .client import AlloraRPCClient
-from .config import AlloraNetworkConfig, AlloraWalletConfig
-from .tx_manager import FeeTier, TxManager
+"""Public exports for RPC client package with lazy loading."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .client import AlloraRPCClient
+    from .config import AlloraNetworkConfig, AlloraWalletConfig
+    from .tx_manager import FeeTier, TxManager
 
 
 __all__ = [
@@ -10,3 +18,15 @@ __all__ = [
     "TxManager",
     "FeeTier",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "AlloraRPCClient":
+        return import_module(".client", __name__).AlloraRPCClient
+    if name in {"AlloraNetworkConfig", "AlloraWalletConfig"}:
+        module = import_module(".config", __name__)
+        return getattr(module, name)
+    if name in {"TxManager", "FeeTier"}:
+        module = import_module(".tx_manager", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/allora_sdk/rpc_client/__init__.py
+++ b/src/allora_sdk/rpc_client/__init__.py
@@ -22,11 +22,17 @@ __all__ = [
 
 def __getattr__(name: str) -> Any:
     if name == "AlloraRPCClient":
-        return import_module(".client", __name__).AlloraRPCClient
+        value = import_module(".client", __name__).AlloraRPCClient
+        globals()[name] = value
+        return value
     if name in {"AlloraNetworkConfig", "AlloraWalletConfig"}:
         module = import_module(".config", __name__)
-        return getattr(module, name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
     if name in {"TxManager", "FeeTier"}:
         module = import_module(".tx_manager", __name__)
-        return getattr(module, name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -164,6 +164,8 @@ class AlloraRPCClient:
     async def close(self):
         """Close client and cleanup resources."""
         logger.debug("Closing Allora client")
+        if self.tx_manager is not None:
+            await self.tx_manager.close(cancel_pending_queue=False)
         if self.events:
             await self.events.stop()
         if self.grpc_client:

--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -16,7 +16,7 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     InputForecast,
     RegisterRequest,
 )
-from allora_sdk.rpc_client.tx_manager import FeeTier, TxManager, PendingTx
+from allora_sdk.rpc_client.tx_manager import FeeTier, PendingTx, TxManager, TxSubmissionHandle
 from allora_sdk.rpc_client.rest import EmissionsV9QueryServiceLike
 
 logger = logging.getLogger("allora_sdk")
@@ -45,7 +45,7 @@ class EmissionsTxs:
         use_queue: bool = False,
         queue_priority: int = 0,
         queue_deadline_at: Optional[datetime] = None,
-    ) -> Union[PendingTx, int]:
+    ) -> Union[TxSubmissionHandle, int]:
         """
         Register as a worker or reputer for a topic.
 
@@ -57,11 +57,14 @@ class EmissionsTxs:
             fee_tier: Fee tier to use (ECO, STANDARD, or PRIORITY)
             gas_limit: Optional gas limit (used only if simulate=False)
             simulate: If True, only simulate and return estimated gas (int).
-                     If False, execute the transaction and return PendingTx.
+                     If False, execute the transaction and return an awaitable tx handle.
+            use_queue: If True, route submission through TxManager queue path.
+            queue_priority: Relative queue priority when use_queue is enabled.
+            queue_deadline_at: Optional deadline used by queue scheduling.
 
         Returns:
             If simulate=True: Estimated gas units required (int)
-            If simulate=False: PendingTx object that can be awaited for the result
+            If simulate=False: Awaitable transaction handle
         """
         msg = RegisterRequest(
             topic_id=topic_id,
@@ -100,7 +103,7 @@ class EmissionsTxs:
         use_queue: bool = False,
         queue_priority: int = 0,
         queue_deadline_at: Optional[datetime] = None,
-    ) -> Union[PendingTx, int]:
+    ) -> Union[TxSubmissionHandle, int]:
         """
         Submit a worker payload (inference/forecast) to the Allora network.
 
@@ -116,11 +119,14 @@ class EmissionsTxs:
             fee_tier: Fee tier (ECO/STANDARD/PRIORITY) - defaults to STANDARD
             gas_limit: Optional gas limit (used only if simulate=False)
             simulate: If True, only simulate and return estimated gas (int).
-                     If False, execute the transaction and return PendingTx.
+                     If False, execute the transaction and return an awaitable tx handle.
+            use_queue: If True, route submission through TxManager queue path.
+            queue_priority: Relative queue priority when use_queue is enabled.
+            queue_deadline_at: Optional deadline used by queue scheduling.
 
         Returns:
             If simulate=True: Estimated gas units required (int)
-            If simulate=False: PendingTx object that can be awaited for the result
+            If simulate=False: Awaitable transaction handle
         """
         if not self._txs:
             raise Exception("No wallet configured. Initialize client with private key or mnemonic.")
@@ -211,7 +217,7 @@ class EmissionsTxs:
         use_queue: bool = False,
         queue_priority: int = 0,
         queue_deadline_at: Optional[datetime] = None,
-    ) -> Union[PendingTx, int]:
+    ) -> Union[TxSubmissionHandle, int]:
 
         msg = DelegateStakeRequest(
             sender=sender,

--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Dict, List, Optional, Union
 from allora_sdk.rpc_client.protos.emissions.v3 import Nonce
 from allora_sdk.rpc_client.protos.emissions.v9 import (
@@ -41,6 +42,9 @@ class EmissionsTxs:
         fee_tier: FeeTier = FeeTier.STANDARD,
         gas_limit: Optional[int] = None,
         simulate: bool = False,
+        use_queue: bool = False,
+        queue_priority: int = 0,
+        queue_deadline_at: Optional[datetime] = None,
     ) -> Union[PendingTx, int]:
         """
         Register as a worker or reputer for a topic.
@@ -76,7 +80,10 @@ class EmissionsTxs:
                 type_url="/emissions.v9.RegisterRequest",
                 msgs=[ msg ],
                 gas_limit=gas_limit,
-                fee_tier=fee_tier
+                fee_tier=fee_tier,
+                use_queue=use_queue,
+                queue_priority=queue_priority,
+                queue_deadline_at=queue_deadline_at,
             )
 
     async def insert_worker_payload(
@@ -90,6 +97,9 @@ class EmissionsTxs:
         fee_tier: FeeTier = FeeTier.STANDARD,
         gas_limit: Optional[int] = None,
         simulate: bool = False,
+        use_queue: bool = False,
+        queue_priority: int = 0,
+        queue_deadline_at: Optional[datetime] = None,
     ) -> Union[PendingTx, int]:
         """
         Submit a worker payload (inference/forecast) to the Allora network.
@@ -182,7 +192,10 @@ class EmissionsTxs:
                 type_url="/emissions.v9.InsertWorkerPayloadRequest",
                 msgs=[ payload_request ],
                 gas_limit=gas_limit,
-                fee_tier=fee_tier
+                fee_tier=fee_tier,
+                use_queue=use_queue,
+                queue_priority=queue_priority,
+                queue_deadline_at=queue_deadline_at,
             )
 
 
@@ -195,6 +208,9 @@ class EmissionsTxs:
         fee_tier: FeeTier = FeeTier.STANDARD,
         gas_limit: Optional[int] = None,
         simulate: bool = False,
+        use_queue: bool = False,
+        queue_priority: int = 0,
+        queue_deadline_at: Optional[datetime] = None,
     ) -> Union[PendingTx, int]:
 
         msg = DelegateStakeRequest(
@@ -214,7 +230,10 @@ class EmissionsTxs:
                 type_url="/emissions.v9.DelegateStakeRequest",
                 msgs=[ msg ],
                 gas_limit=gas_limit,
-                fee_tier=fee_tier
+                fee_tier=fee_tier,
+                use_queue=use_queue,
+                queue_priority=queue_priority,
+                queue_deadline_at=queue_deadline_at,
             )
 
     async def create_topic(

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass
 from decimal import Decimal
 import logging
-from typing import Any, Optional, Union, Dict, Protocol, cast
+from typing import Any, Dict, Generator, Optional, Protocol, Union, cast
 from google.protobuf.message import Message
 
 from cosmpy.aerial.wallet import LocalWallet
@@ -133,12 +133,24 @@ class PendingTx:
         return self.wait().__await__()
 
 
+class TxSubmissionHandle(Protocol):
+    """Common awaitable contract for transaction submission handles."""
+
+    async def wait(self) -> TxResponse:
+        """Wait for final transaction result."""
+
+    def __await__(self) -> Generator[Any, None, TxResponse]:
+        """Allow awaiting the handle directly."""
+
+
 @dataclass(slots=True)
 class _QueuedSubmission:
     type_url: str
     msgs: list[Any]
     gas_limit: Optional[int]
     fee_tier: "FeeTier"
+    retry_attempt: int = 0
+    fee_multiplier_override: Optional[float] = None
 
 class FeeTier(Enum):
     ECO      = "eco"
@@ -263,7 +275,7 @@ class TxManager:
         use_queue: bool = False,
         queue_priority: int = 0,
         queue_deadline_at: Optional[datetime] = None,
-    ):
+    ) -> TxSubmissionHandle:
         if self.wallet is None:
             raise Exception('No wallet configured. Initialize client with private key or mnemonic.')
 
@@ -494,25 +506,40 @@ class TxManager:
 
     async def _submit_via_queue(self, payload: _QueuedSubmission, sequence: Optional[int]) -> TxResponse:
         await self._pre_flight_checks()
+        attempt = payload.retry_attempt
+        gas_multiplier = 1.0 + (attempt * 0.3)
+        fee_multiplier = payload.fee_multiplier_override
+        if fee_multiplier is None:
+            fee_multiplier = self._fee_multipliers[payload.fee_tier]
 
-        fee_multiplier = self._fee_multipliers[payload.fee_tier]
-        tx_hash, _, _ = await self._build_and_broadcast(
-            payload.type_url,
-            payload.msgs,
-            payload.gas_limit,
-            fee_multiplier,
-            gas_multiplier=1.0,
-            sequence=sequence,
-        )
-        resp = await self.wait_for_tx(
-            tx_hash,
-            timeout=timedelta(seconds=30),
-            poll_period=timedelta(seconds=2),
-        )
-        assert resp.tx_response is not None
-        self._log_tx_response(resp.tx_response)
-        self._raise_for_status(resp.tx_response)
-        return resp.tx_response
+        try:
+            tx_hash, _, _ = await self._build_and_broadcast(
+                payload.type_url,
+                payload.msgs,
+                payload.gas_limit,
+                fee_multiplier,
+                gas_multiplier=gas_multiplier,
+                sequence=sequence,
+            )
+            resp = await self.wait_for_tx(
+                tx_hash,
+                timeout=timedelta(seconds=30),
+                poll_period=timedelta(seconds=2),
+            )
+            assert resp.tx_response is not None
+            self._log_tx_response(resp.tx_response)
+            self._raise_for_status(resp.tx_response)
+            return resp.tx_response
+        except InsufficientFeesError:
+            # Invalidate gas-price cache and raise retry fee, mirroring legacy retry behavior.
+            self._cached_gas_price = None
+            self._gas_price_cache_time = None
+            payload.fee_multiplier_override = 1.0 + (attempt * 0.5)
+            payload.retry_attempt = attempt + 1
+            raise
+        except Exception:
+            payload.retry_attempt = attempt + 1
+            raise
 
 
     async def _build_and_broadcast(

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -2,9 +2,10 @@ import asyncio
 from enum import Enum
 import grpc
 from datetime import datetime, timedelta
+from dataclasses import dataclass
 from decimal import Decimal
 import logging
-from typing import Any, Optional, Union, Dict, cast
+from typing import Any, Optional, Union, Dict, Protocol, cast
 from google.protobuf.message import Message
 
 from cosmpy.aerial.wallet import LocalWallet
@@ -14,17 +15,82 @@ from cosmpy.aerial.client.utils import ensure_timedelta
 from cosmpy.protos.cosmos.tx.v1beta1.tx_pb2 import TxRaw as CosmpyTxRaw
 
 from allora_sdk.rpc_client.config import AlloraNetworkConfig
-from allora_sdk.rpc_client.protos.cosmos.auth.v1beta1 import QueryAccountInfoRequest, QueryAccountRequest
-from allora_sdk.rpc_client.protos.cosmos.bank.v1beta1 import QueryBalanceRequest
-from allora_sdk.rpc_client.protos.cosmos.base.abci.v1beta1 import TxResponse
-from allora_sdk.rpc_client.protos.cosmos.tx.v1beta1 import BroadcastMode, BroadcastTxRequest, GetTxRequest, SimulateRequest
-from allora_sdk.rpc_client.protos.feemarket.feemarket.v1 import GasPriceRequest, StateRequest, ParamsRequest
-from allora_sdk.rpc_client.interfaces import (
-    CosmosAuthV1Beta1QueryLike,
-    CosmosBankV1Beta1QueryLike,
-    CosmosTxV1Beta1ServiceLike,
-    FeemarketFeemarketV1QueryLike,
-)
+try:
+    from allora_sdk.rpc_client.interfaces import (
+        CosmosAuthV1Beta1QueryLike,
+        CosmosBankV1Beta1QueryLike,
+        CosmosTxV1Beta1ServiceLike,
+        FeemarketFeemarketV1QueryLike,
+    )
+except ModuleNotFoundError:
+    # Fallback protocols for environments where generated interface shims are absent.
+    class CosmosTxV1Beta1ServiceLike(Protocol):
+        async def simulate(self, request: Any) -> Any: ...
+        async def broadcast_tx(self, request: Any) -> Any: ...
+        async def get_tx(self, request: Any) -> Any: ...
+
+    class CosmosAuthV1Beta1QueryLike(Protocol):
+        async def account_info(self, request: Any) -> Any: ...
+        async def account(self, request: Any) -> Any: ...
+
+    class CosmosBankV1Beta1QueryLike(Protocol):
+        async def balance(self, request: Any) -> Any: ...
+
+    class FeemarketFeemarketV1QueryLike(Protocol):
+        async def gas_price(self, request: Any) -> Any: ...
+        async def state(self, request: Any) -> Any: ...
+        async def params(self, request: Any) -> Any: ...
+
+try:
+    from allora_sdk.rpc_client.protos.cosmos.auth.v1beta1 import QueryAccountInfoRequest, QueryAccountRequest
+    from allora_sdk.rpc_client.protos.cosmos.bank.v1beta1 import QueryBalanceRequest
+    from allora_sdk.rpc_client.protos.cosmos.base.abci.v1beta1 import TxResponse
+    from allora_sdk.rpc_client.protos.cosmos.tx.v1beta1 import BroadcastMode, BroadcastTxRequest, GetTxRequest, SimulateRequest
+    from allora_sdk.rpc_client.protos.feemarket.feemarket.v1 import GasPriceRequest, StateRequest, ParamsRequest
+except ModuleNotFoundError:
+    class _RequestMessage:
+        """Minimal request object used when generated protos are unavailable."""
+
+        def __init__(self, **kwargs: Any):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class QueryAccountInfoRequest(_RequestMessage):
+        pass
+
+    class QueryAccountRequest(_RequestMessage):
+        pass
+
+    class QueryBalanceRequest(_RequestMessage):
+        pass
+
+    class BroadcastTxRequest(_RequestMessage):
+        pass
+
+    class GetTxRequest(_RequestMessage):
+        pass
+
+    class SimulateRequest(_RequestMessage):
+        pass
+
+    class GasPriceRequest(_RequestMessage):
+        pass
+
+    class StateRequest(_RequestMessage):
+        pass
+
+    class ParamsRequest(_RequestMessage):
+        pass
+
+    class BroadcastMode(Enum):
+        SYNC = "sync"
+
+    @dataclass
+    class TxResponse:
+        code: int = 0
+        raw_log: str = ""
+        txhash: str = ""
+        codespace: str = ""
 
 logger = logging.getLogger("allora_sdk")
 

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -15,6 +15,7 @@ from cosmpy.aerial.client.utils import ensure_timedelta
 from cosmpy.protos.cosmos.tx.v1beta1.tx_pb2 import TxRaw as CosmpyTxRaw
 
 from allora_sdk.rpc_client.config import AlloraNetworkConfig
+from allora_sdk.rpc_client.tx_queue import ErrorClassification, TransactionQueue, TxQueueAdapter
 try:
     from allora_sdk.rpc_client.interfaces import (
         CosmosAuthV1Beta1QueryLike,
@@ -131,6 +132,14 @@ class PendingTx:
     def __await__(self):
         return self.wait().__await__()
 
+
+@dataclass(slots=True)
+class _QueuedSubmission:
+    type_url: str
+    msgs: list[Any]
+    gas_limit: Optional[int]
+    fee_tier: "FeeTier"
+
 class FeeTier(Enum):
     ECO      = "eco"
     STANDARD = "standard"
@@ -167,6 +176,29 @@ class TxNotFoundError(Exception):
 
 class TxTimeoutError(Exception):
     pass
+
+
+class _TxManagerQueueAdapter(TxQueueAdapter[_QueuedSubmission, TxResponse]):
+    """Adapter that maps TxManager operations onto TransactionQueue."""
+
+    def __init__(self, manager: "TxManager") -> None:
+        self._manager = manager
+
+    async def fetch_sequence(self, account_id: str) -> int:
+        return await self._manager._fetch_account_sequence(account_id)
+
+    async def submit(self, payload: _QueuedSubmission, sequence: Optional[int]) -> TxResponse:
+        return await self._manager._submit_via_queue(payload, sequence)
+
+    def classify_error(self, err: Exception) -> ErrorClassification:
+        if isinstance(err, AccountSequenceMismatchError):
+            return ErrorClassification.SEQUENCE_MISMATCH
+        if isinstance(err, (OutOfGasError, InsufficientFeesError, TxTimeoutError)):
+            return ErrorClassification.RETRYABLE
+        return ErrorClassification.FATAL
+
+    def is_timeout(self, err: Exception) -> bool:
+        return isinstance(err, (TxTimeoutError, asyncio.TimeoutError))
 
 
 class TxManager:
@@ -217,6 +249,8 @@ class TxManager:
         self._cached_gas_price: Optional[Decimal] = None
         self._gas_price_cache_time: Optional[datetime] = None
         self._gas_price_cache_ttl_secs: int = config.gas_price_cache_ttl_secs
+        self._tx_queue: Optional[TransactionQueue[_QueuedSubmission, TxResponse]] = None
+        self._tx_queue_lock = asyncio.Lock()
 
     async def submit_transaction(
         self,
@@ -226,9 +260,32 @@ class TxManager:
         fee_tier: FeeTier = FeeTier.STANDARD,
         max_retries: int = 2,
         timeout: Optional[timedelta] = None,
+        use_queue: bool = False,
+        queue_priority: int = 0,
+        queue_deadline_at: Optional[datetime] = None,
     ):
         if self.wallet is None:
             raise Exception('No wallet configured. Initialize client with private key or mnemonic.')
+
+        if use_queue:
+            tx_queue = await self._ensure_tx_queue_started()
+            queued_submission = _QueuedSubmission(
+                type_url=type_url,
+                msgs=msgs,
+                gas_limit=gas_limit,
+                fee_tier=fee_tier,
+            )
+            queue_handle = await tx_queue.enqueue(
+                request_id=f"tx-{self.parent_tx_id}",
+                account_id=str(self.wallet.address()),
+                payload=queued_submission,
+                priority=queue_priority,
+                deadline_at=queue_deadline_at,
+                max_retries=max_retries,
+                timeout=timeout,
+            )
+            self.parent_tx_id += 1
+            return queue_handle
 
         pending = PendingTx(
             manager=self,
@@ -245,6 +302,13 @@ class TxManager:
         asyncio.create_task(self._attempt_submissions(pending, gas_limit))
 
         return pending
+
+    async def close(self, *, cancel_pending_queue: bool = False) -> None:
+        """Stop queue-backed processing if initialized."""
+        if self._tx_queue is None:
+            return
+        await self._tx_queue.stop(cancel_pending=cancel_pending_queue)
+        self._tx_queue = None
     
     async def simulate_transaction(
         self,
@@ -410,6 +474,46 @@ class TxManager:
         # Exhausted attempts without setting result
         pending._final_future.set_exception(TxTimeoutError("Transaction failed after maximum retries"))
 
+    async def _fetch_account_sequence(self, account_id: str) -> int:
+        resp = await self.auth_client.account_info(QueryAccountInfoRequest(address=account_id))
+        if resp.info is None:
+            raise Exception("account_info query response is none")
+        return int(resp.info.sequence)
+
+    async def _ensure_tx_queue_started(self) -> TransactionQueue[_QueuedSubmission, TxResponse]:
+        if self._tx_queue is not None:
+            return self._tx_queue
+
+        async with self._tx_queue_lock:
+            if self._tx_queue is None:
+                self._tx_queue = TransactionQueue(
+                    adapter=_TxManagerQueueAdapter(self),
+                )
+                await self._tx_queue.start()
+            return self._tx_queue
+
+    async def _submit_via_queue(self, payload: _QueuedSubmission, sequence: Optional[int]) -> TxResponse:
+        await self._pre_flight_checks()
+
+        fee_multiplier = self._fee_multipliers[payload.fee_tier]
+        tx_hash, _, _ = await self._build_and_broadcast(
+            payload.type_url,
+            payload.msgs,
+            payload.gas_limit,
+            fee_multiplier,
+            gas_multiplier=1.0,
+            sequence=sequence,
+        )
+        resp = await self.wait_for_tx(
+            tx_hash,
+            timeout=timedelta(seconds=30),
+            poll_period=timedelta(seconds=2),
+        )
+        assert resp.tx_response is not None
+        self._log_tx_response(resp.tx_response)
+        self._raise_for_status(resp.tx_response)
+        return resp.tx_response
+
 
     async def _build_and_broadcast(
         self,
@@ -418,6 +522,7 @@ class TxManager:
         gas_limit: Optional[int],
         fee_multiplier: float,
         gas_multiplier: float,
+        sequence: Optional[int] = None,
     ) -> tuple[str, int, Coin]:
         any_messages = [ self._create_any_message(msg, type_url) for msg in msgs ]
 
@@ -435,10 +540,11 @@ class TxManager:
         if resp.info is None:
             raise Exception('account_info query response is none')
         info = resp.info
+        sequence_number = info.sequence if sequence is None else sequence
         logger.debug(f"Account info: seq={info.sequence}, num={info.account_number}")
 
         tx.seal(
-            signing_cfgs=[ SigningCfg.direct(self.wallet.public_key(), sequence_num=info.sequence) ],
+            signing_cfgs=[ SigningCfg.direct(self.wallet.public_key(), sequence_num=sequence_number) ],
             fee=TxFee(amount=[ fee ], gas_limit=gas_limit),
         )
 

--- a/src/allora_sdk/rpc_client/tx_queue.py
+++ b/src/allora_sdk/rpc_client/tx_queue.py
@@ -1,0 +1,383 @@
+import asyncio
+import heapq
+import random
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Callable, Deque, Dict, Generic, Optional, Protocol, TypeVar
+
+
+TPayload = TypeVar("TPayload")
+TResult = TypeVar("TResult")
+
+
+class ErrorClassification(Enum):
+    RETRYABLE = "retryable"
+    SEQUENCE_MISMATCH = "sequence_mismatch"
+    FATAL = "fatal"
+    EXPIRED = "expired"
+
+
+class TxQueueError(Exception):
+    """Base exception for transaction queue errors."""
+
+
+class TxQueueNotStartedError(TxQueueError):
+    """Raised when enqueue is called before queue start."""
+
+
+class TxQueueStoppedError(TxQueueError):
+    """Raised when queue is stopped and cannot accept new work."""
+
+
+class TxDeadlineExceededError(TxQueueError):
+    """Raised when a transaction misses its deadline."""
+
+
+class TxRetryExhaustedError(TxQueueError):
+    """Raised when retries are exhausted for an item."""
+
+
+class TxQueueAdapter(Protocol[TPayload, TResult]):
+    async def fetch_sequence(self, account_id: str) -> int:
+        """Fetch current account sequence from source of truth."""
+
+    async def submit(self, payload: TPayload, sequence: Optional[int]) -> TResult:
+        """Submit a transaction payload with optional sequence."""
+
+    def classify_error(self, err: Exception) -> ErrorClassification:
+        """Classify submission errors into queue behavior buckets."""
+
+    def is_timeout(self, err: Exception) -> bool:
+        """Whether an exception should be treated as timeout-like retryable."""
+
+
+@dataclass(slots=True)
+class QueueItem(Generic[TPayload, TResult]):
+    request_id: str
+    account_id: str
+    payload: TPayload
+    priority: int
+    deadline_at: Optional[datetime]
+    max_retries: int
+    timeout: Optional[timedelta]
+    metadata: Dict[str, Any]
+    created_at: datetime
+    handle: "PendingQueueTx[TResult]"
+
+
+@dataclass(slots=True, order=True)
+class _QueueEntry(Generic[TPayload, TResult]):
+    sort_key: tuple[Any, ...]
+    item: QueueItem[TPayload, TResult] = field(compare=False)
+    sequence_no: int = field(compare=False)
+
+
+class PendingQueueTx(Generic[TResult]):
+    def __init__(self) -> None:
+        self.created_at = datetime.now()
+        self._final_future: asyncio.Future[TResult] = asyncio.get_running_loop().create_future()
+
+    async def wait(self) -> TResult:
+        return await self._final_future
+
+    def __await__(self):
+        return self.wait().__await__()
+
+
+class SequenceState:
+    """Per-account sequence cache with invalidation and atomic updates."""
+
+    def __init__(self) -> None:
+        self._sequences: Dict[str, int] = {}
+        self._locks: Dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    async def current_or_fetch(self, adapter: TxQueueAdapter[Any, Any], account_id: str) -> int:
+        async with self._locks[account_id]:
+            if account_id not in self._sequences:
+                self._sequences[account_id] = await adapter.fetch_sequence(account_id)
+            return self._sequences[account_id]
+
+    async def invalidate(self, account_id: str) -> None:
+        async with self._locks[account_id]:
+            self._sequences.pop(account_id, None)
+
+    async def advance(self, account_id: str) -> None:
+        async with self._locks[account_id]:
+            if account_id in self._sequences:
+                self._sequences[account_id] += 1
+
+
+class TransactionQueue(Generic[TPayload, TResult]):
+    def __init__(
+        self,
+        adapter: TxQueueAdapter[TPayload, TResult],
+        *,
+        min_priority: int = 0,
+        max_priority: int = 100,
+        starvation_threshold: timedelta = timedelta(seconds=30),
+        max_age_boost: int = 20,
+        retry_backoff_base: float = 0.1,
+        retry_backoff_max: float = 2.0,
+        now_fn: Callable[[], datetime] = datetime.now,
+        sleep_fn: Callable[[float], Any] = asyncio.sleep,
+        random_fn: Callable[[], float] = random.random,
+    ) -> None:
+        self.adapter = adapter
+        self.min_priority = min_priority
+        self.max_priority = max_priority
+        self.starvation_threshold = starvation_threshold
+        self.max_age_boost = max_age_boost
+        self.retry_backoff_base = retry_backoff_base
+        self.retry_backoff_max = retry_backoff_max
+        self._now_fn = now_fn
+        self._sleep_fn = sleep_fn
+        self._random_fn = random_fn
+
+        self._sequence_state = SequenceState()
+        self._queue_lock = asyncio.Lock()
+        self._global_queue: list[_QueueEntry[TPayload, TResult]] = []
+        self._account_queues: Dict[str, Deque[QueueItem[TPayload, TResult]]] = defaultdict(deque)
+        self._account_workers: Dict[str, asyncio.Task[None]] = {}
+        self._inflight_items: Dict[str, QueueItem[TPayload, TResult]] = {}
+        self._busy_accounts: set[str] = set()
+        self._scheduler_task: Optional[asyncio.Task[None]] = None
+        self._new_item_event = asyncio.Event()
+        self._is_started = False
+        self._is_stopped = False
+        self._sequence_counter = 0
+
+    async def start(self) -> None:
+        if self._is_started:
+            return
+        if self._is_stopped:
+            raise TxQueueStoppedError("Queue is stopped and cannot be restarted")
+        self._is_started = True
+        self._scheduler_task = asyncio.create_task(self._scheduler_loop())
+
+    async def stop(self, *, cancel_pending: bool = False) -> None:
+        self._is_stopped = True
+        self._new_item_event.set()
+
+        if self._scheduler_task is not None:
+            await self._scheduler_task
+
+        if cancel_pending:
+            for inflight in list(self._inflight_items.values()):
+                if not inflight.handle._final_future.done():
+                    inflight.handle._final_future.set_exception(TxQueueStoppedError("Queue stopped"))
+
+            async with self._queue_lock:
+                for entry in self._global_queue:
+                    if not entry.item.handle._final_future.done():
+                        entry.item.handle._final_future.set_exception(TxQueueStoppedError("Queue stopped"))
+                self._global_queue.clear()
+
+                for items in self._account_queues.values():
+                    while items:
+                        item = items.popleft()
+                        if not item.handle._final_future.done():
+                            item.handle._final_future.set_exception(TxQueueStoppedError("Queue stopped"))
+        else:
+            # Drain unscheduled global items to account workers, then let workers finish naturally.
+            async with self._queue_lock:
+                self._refresh_global_heap()
+                while self._global_queue:
+                    entry = heapq.heappop(self._global_queue)
+                    self._account_queues[entry.item.account_id].append(entry.item)
+                    self._ensure_account_worker(entry.item.account_id)
+
+        worker_tasks = list(self._account_workers.values())
+        if cancel_pending:
+            for task in worker_tasks:
+                task.cancel()
+            if worker_tasks:
+                await asyncio.gather(*worker_tasks, return_exceptions=True)
+            return
+
+        if worker_tasks:
+            await asyncio.gather(*worker_tasks)
+
+    async def enqueue(
+        self,
+        *,
+        request_id: str,
+        account_id: str,
+        payload: TPayload,
+        priority: int = 0,
+        deadline_at: Optional[datetime] = None,
+        max_retries: int = 2,
+        timeout: Optional[timedelta] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> PendingQueueTx[TResult]:
+        if not self._is_started:
+            raise TxQueueNotStartedError("Queue not started")
+        if self._is_stopped:
+            raise TxQueueStoppedError("Queue stopped")
+        if max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+
+        clamped_priority = max(self.min_priority, min(self.max_priority, priority))
+        handle = PendingQueueTx[TResult]()
+        item = QueueItem[TPayload, TResult](
+            request_id=request_id,
+            account_id=account_id,
+            payload=payload,
+            priority=clamped_priority,
+            deadline_at=deadline_at,
+            max_retries=max_retries,
+            timeout=timeout,
+            metadata=metadata or {},
+            created_at=self._now_fn(),
+            handle=handle,
+        )
+
+        async with self._queue_lock:
+            if self._is_stopped:
+                raise TxQueueStoppedError("Queue stopped")
+            entry = _QueueEntry(
+                sort_key=self._compute_sort_key(item),
+                item=item,
+                sequence_no=self._sequence_counter,
+            )
+            self._sequence_counter += 1
+            heapq.heappush(self._global_queue, entry)
+            self._new_item_event.set()
+
+        return handle
+
+    def _compute_effective_priority(self, item: QueueItem[TPayload, TResult]) -> int:
+        age = self._now_fn() - item.created_at
+        if age < self.starvation_threshold:
+            return item.priority
+        boosts = int(age.total_seconds() // max(1, int(self.starvation_threshold.total_seconds())))
+        return min(self.max_priority, item.priority + min(self.max_age_boost, boosts))
+
+    def _compute_sort_key(self, item: QueueItem[TPayload, TResult]) -> tuple[Any, ...]:
+        deadline_key = (0, item.deadline_at) if item.deadline_at is not None else (1, datetime.max)
+        effective_priority = self._compute_effective_priority(item)
+        return (deadline_key[0], deadline_key[1], -effective_priority, item.created_at)
+
+    async def _scheduler_loop(self) -> None:
+        while True:
+            if self._is_stopped:
+                return
+
+            self._new_item_event.clear()
+            scheduled_any = await self._schedule_ready_items()
+            if scheduled_any:
+                continue
+
+            await self._new_item_event.wait()
+
+    async def _schedule_ready_items(self) -> bool:
+        scheduled = False
+
+        while True:
+            async with self._queue_lock:
+                if not self._global_queue:
+                    return scheduled
+
+                self._refresh_global_heap()
+                candidate_idx = self._pick_available_item_index()
+                if candidate_idx is None:
+                    return scheduled
+
+                entry = self._global_queue.pop(candidate_idx)
+                heapq.heapify(self._global_queue)
+
+                item = entry.item
+                self._account_queues[item.account_id].append(item)
+                self._ensure_account_worker(item.account_id)
+                scheduled = True
+
+    def _pick_available_item_index(self) -> Optional[int]:
+        best_idx: Optional[int] = None
+        best_key: Optional[tuple[Any, ...]] = None
+        for idx, entry in enumerate(self._global_queue):
+            account_id = entry.item.account_id
+            if account_id in self._busy_accounts:
+                continue
+            if best_key is None or entry.sort_key < best_key:
+                best_key = entry.sort_key
+                best_idx = idx
+        return best_idx
+
+    def _refresh_global_heap(self) -> None:
+        for entry in self._global_queue:
+            entry.sort_key = self._compute_sort_key(entry.item)
+        heapq.heapify(self._global_queue)
+
+    def _ensure_account_worker(self, account_id: str) -> None:
+        task = self._account_workers.get(account_id)
+        if task is not None and not task.done():
+            return
+        self._account_workers[account_id] = asyncio.create_task(self._account_worker(account_id))
+
+    async def _account_worker(self, account_id: str) -> None:
+        self._busy_accounts.add(account_id)
+        try:
+            while True:
+                queue = self._account_queues[account_id]
+                if not queue:
+                    return
+                item = queue.popleft()
+                self._inflight_items[account_id] = item
+                try:
+                    await self._process_item(item)
+                finally:
+                    self._inflight_items.pop(account_id, None)
+        finally:
+            self._busy_accounts.discard(account_id)
+            self._new_item_event.set()
+
+    async def _process_item(self, item: QueueItem[TPayload, TResult]) -> None:
+        if item.deadline_at is not None and self._now_fn() >= item.deadline_at:
+            if not item.handle._final_future.done():
+                item.handle._final_future.set_exception(TxDeadlineExceededError(f"Deadline exceeded for request {item.request_id}"))
+            return
+
+        for attempt in range(item.max_retries + 1):
+            try:
+                if item.deadline_at is not None and self._now_fn() >= item.deadline_at:
+                    raise TxDeadlineExceededError(f"Deadline exceeded for request {item.request_id}")
+
+                sequence = await self._sequence_state.current_or_fetch(self.adapter, item.account_id)
+                if item.timeout is None:
+                    result = await self.adapter.submit(item.payload, sequence)
+                else:
+                    result = await asyncio.wait_for(
+                        self.adapter.submit(item.payload, sequence),
+                        timeout=item.timeout.total_seconds(),
+                    )
+                await self._sequence_state.advance(item.account_id)
+                if not item.handle._final_future.done():
+                    item.handle._final_future.set_result(result)
+                return
+            except TxDeadlineExceededError as err:
+                if not item.handle._final_future.done():
+                    item.handle._final_future.set_exception(err)
+                return
+            except Exception as err:
+                classification = ErrorClassification.RETRYABLE if self.adapter.is_timeout(err) else self.adapter.classify_error(err)
+                if classification == ErrorClassification.SEQUENCE_MISMATCH:
+                    await self._sequence_state.invalidate(item.account_id)
+                should_retry = classification in (ErrorClassification.RETRYABLE, ErrorClassification.SEQUENCE_MISMATCH)
+                if not should_retry or attempt >= item.max_retries or classification == ErrorClassification.EXPIRED:
+                    if not item.handle._final_future.done():
+                        if classification in (ErrorClassification.RETRYABLE, ErrorClassification.SEQUENCE_MISMATCH):
+                            exhausted_err = TxRetryExhaustedError(f"Retries exhausted for request {item.request_id}")
+                            exhausted_err.__cause__ = err
+                            item.handle._final_future.set_exception(exhausted_err)
+                        elif classification == ErrorClassification.EXPIRED:
+                            expired_err = TxDeadlineExceededError(f"Expired request {item.request_id}")
+                            expired_err.__cause__ = err
+                            item.handle._final_future.set_exception(expired_err)
+                        else:
+                            item.handle._final_future.set_exception(err)
+                    return
+
+                delay = min(self.retry_backoff_max, self.retry_backoff_base * (2 ** attempt))
+                jitter_multiplier = 0.5 + self._random_fn()
+                await self._sleep_fn(delay * jitter_multiplier)

--- a/src/allora_sdk/rpc_client/tx_queue.py
+++ b/src/allora_sdk/rpc_client/tx_queue.py
@@ -236,10 +236,11 @@ class TransactionQueue(Generic[TPayload, TResult]):
         async with self._queue_lock:
             if self._is_stopped:
                 raise TxQueueStoppedError("Queue stopped")
+            sequence_no = self._sequence_counter
             entry = _QueueEntry(
-                sort_key=self._compute_sort_key(item),
+                sort_key=self._compute_sort_key(item, sequence_no),
                 item=item,
-                sequence_no=self._sequence_counter,
+                sequence_no=sequence_no,
             )
             self._sequence_counter += 1
             heapq.heappush(self._global_queue, entry)
@@ -254,10 +255,10 @@ class TransactionQueue(Generic[TPayload, TResult]):
         boosts = int(age.total_seconds() // max(1, int(self.starvation_threshold.total_seconds())))
         return min(self.max_priority, item.priority + min(self.max_age_boost, boosts))
 
-    def _compute_sort_key(self, item: QueueItem[TPayload, TResult]) -> tuple[Any, ...]:
+    def _compute_sort_key(self, item: QueueItem[TPayload, TResult], sequence_no: int) -> tuple[Any, ...]:
         deadline_key = (0, item.deadline_at) if item.deadline_at is not None else (1, datetime.max)
         effective_priority = self._compute_effective_priority(item)
-        return (deadline_key[0], deadline_key[1], -effective_priority, item.created_at)
+        return (deadline_key[0], deadline_key[1], -effective_priority, item.created_at, sequence_no)
 
     async def _scheduler_loop(self) -> None:
         while True:
@@ -306,7 +307,7 @@ class TransactionQueue(Generic[TPayload, TResult]):
 
     def _refresh_global_heap(self) -> None:
         for entry in self._global_queue:
-            entry.sort_key = self._compute_sort_key(entry.item)
+            entry.sort_key = self._compute_sort_key(entry.item, entry.sequence_no)
         heapq.heapify(self._global_queue)
 
     def _ensure_account_worker(self, account_id: str) -> None:

--- a/tests/test_api_client_integration.py
+++ b/tests/test_api_client_integration.py
@@ -12,7 +12,10 @@ DEFAULT_TEST_TIMEOUT = 30  # 30 seconds
 
 @pytest_asyncio.fixture
 def client():
-    return AlloraAPIClient(chain_id=ChainID.TESTNET, api_key=os.getenv("ALLORA_API_KEY"))
+    api_key = os.getenv("ALLORA_API_KEY")
+    if not api_key:
+        pytest.skip("ALLORA_API_KEY is not set; skipping integration tests")
+    return AlloraAPIClient(chain_id=ChainID.TESTNET, api_key=api_key)
 
 @pytest.mark.asyncio
 async def test_get_all_topics(client):

--- a/tests/test_lazy_exports_unit.py
+++ b/tests/test_lazy_exports_unit.py
@@ -1,0 +1,24 @@
+import allora_sdk
+import allora_sdk.rpc_client as rpc_client
+
+
+def test_top_level_lazy_exports_are_cached_in_module_globals() -> None:
+    name = "setup_sdk_logging"
+    allora_sdk.__dict__.pop(name, None)
+
+    resolved = getattr(allora_sdk, name)
+
+    assert name in allora_sdk.__dict__
+    assert allora_sdk.__dict__[name] is resolved
+    assert getattr(allora_sdk, name) is resolved
+
+
+def test_rpc_client_lazy_exports_are_cached_in_module_globals() -> None:
+    name = "AlloraNetworkConfig"
+    rpc_client.__dict__.pop(name, None)
+
+    resolved = getattr(rpc_client, name)
+
+    assert name in rpc_client.__dict__
+    assert rpc_client.__dict__[name] is resolved
+    assert getattr(rpc_client, name) is resolved

--- a/tests/test_lazy_exports_unit.py
+++ b/tests/test_lazy_exports_unit.py
@@ -3,6 +3,7 @@ import allora_sdk.rpc_client as rpc_client
 
 
 def test_top_level_lazy_exports_are_cached_in_module_globals() -> None:
+    """Verify top-level lazy-loaded exports are cached after first lookup."""
     name = "setup_sdk_logging"
     allora_sdk.__dict__.pop(name, None)
 
@@ -14,6 +15,7 @@ def test_top_level_lazy_exports_are_cached_in_module_globals() -> None:
 
 
 def test_rpc_client_lazy_exports_are_cached_in_module_globals() -> None:
+    """Verify rpc_client lazy-loaded exports are cached after first lookup."""
     name = "AlloraNetworkConfig"
     rpc_client.__dict__.pop(name, None)
 

--- a/tests/test_tx_manager_fee_calculation.py
+++ b/tests/test_tx_manager_fee_calculation.py
@@ -3,10 +3,9 @@ Test that TxManager correctly calculates fees using feemarket gas prices.
 """
 import pytest
 from unittest.mock import Mock
+from types import SimpleNamespace
 from allora_sdk.rpc_client.tx_manager import TxManager
 from allora_sdk.rpc_client.config import AlloraNetworkConfig
-from allora_sdk.rpc_client.protos.feemarket.feemarket.v1 import GasPriceResponse
-from allora_sdk.rpc_client.protos.cosmos.base.v1beta1 import DecCoin
 
 
 @pytest.mark.asyncio
@@ -21,10 +20,10 @@ async def test_fee_calculation_with_dynamic_prices():
 
     # Mock feemarket client returning price in cosmos.Dec format (18 decimals)
     feemarket_client = Mock()
-    mock_response = GasPriceResponse(
-        price=DecCoin(
+    mock_response = SimpleNamespace(
+        price=SimpleNamespace(
             denom="uallo",
-            amount="10000000000000000000"  # 10.0 in cosmos.Dec format
+            amount="10000000000000000000",  # 10.0 in cosmos.Dec format
         )
     )
     feemarket_client.gas_price = Mock(return_value=mock_response)

--- a/tests/test_tx_manager_queue_unit.py
+++ b/tests/test_tx_manager_queue_unit.py
@@ -1,0 +1,150 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from typing import Any, cast
+
+import pytest
+
+from allora_sdk.rpc_client.client_emissions import EmissionsTxs
+from allora_sdk.rpc_client.config import AlloraNetworkConfig
+from allora_sdk.rpc_client.tx_manager import FeeTier, PendingTx, TxManager
+
+
+def _make_tx_manager() -> TxManager:
+    wallet = Mock()
+    wallet.address.return_value = "allo1unit"
+    wallet.public_key.return_value = Mock()
+    wallet.signer.return_value = Mock()
+
+    return TxManager(
+        wallet=wallet,
+        tx_client=Mock(),
+        auth_client=Mock(),
+        bank_client=Mock(),
+        feemarket_client=Mock(),
+        config=AlloraNetworkConfig.testnet(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_transaction_default_path_still_returns_pending_tx() -> None:
+    """Verify non-queue submit path remains backward compatible."""
+    manager = _make_tx_manager()
+
+    async def fake_attempt_submissions(pending: PendingTx, gas_limit: int | None) -> None:
+        del gas_limit
+        pending._final_future.set_result(cast(Any, SimpleNamespace(code=0, txhash="default-path")))
+
+    manager._attempt_submissions = fake_attempt_submissions  # type: ignore[method-assign]
+
+    pending = await manager.submit_transaction(
+        type_url="/cosmos.bank.v1beta1.MsgSend",
+        msgs=[],
+        max_retries=0,
+    )
+
+    assert isinstance(pending, PendingTx)
+    result = await pending
+    assert result.txhash == "default-path"
+
+
+@pytest.mark.asyncio
+async def test_submit_transaction_queue_path_reuses_sequence_cache() -> None:
+    """Verify queue submit path advances sequence and reuses cached fetch."""
+    manager = _make_tx_manager()
+    manager._fetch_account_sequence = AsyncMock(return_value=10)  # type: ignore[method-assign]
+    submitted_sequences: list[int | None] = []
+
+    async def fake_submit_via_queue(payload: object, sequence: int | None):
+        del payload
+        submitted_sequences.append(sequence)
+        assert sequence is not None
+        return SimpleNamespace(code=0, txhash=f"queued-{sequence}")
+
+    manager._submit_via_queue = fake_submit_via_queue  # type: ignore[method-assign]
+
+    first = await manager.submit_transaction(
+        type_url="/emissions.v9.InsertWorkerPayloadRequest",
+        msgs=[],
+        use_queue=True,
+        queue_priority=50,
+        queue_deadline_at=datetime.now() + timedelta(seconds=10),
+    )
+    second = await manager.submit_transaction(
+        type_url="/emissions.v9.InsertWorkerPayloadRequest",
+        msgs=[],
+        use_queue=True,
+        queue_priority=50,
+        queue_deadline_at=datetime.now() + timedelta(seconds=10),
+    )
+
+    first_resp = await first
+    second_resp = await second
+
+    assert first_resp.txhash == "queued-10"
+    assert second_resp.txhash == "queued-11"
+    assert submitted_sequences == [10, 11]
+    assert manager._fetch_account_sequence.await_count == 1
+    await manager.close(cancel_pending_queue=False)
+
+
+class _FakePublicKey:
+    public_key_hex = "abcd"
+
+
+class _FakeSigner:
+    def sign_digest(self, digest: bytes) -> bytes:
+        del digest
+        return b"sig"
+
+
+class _FakeWallet:
+    def address(self) -> str:
+        return "allo1worker"
+
+    def public_key(self) -> _FakePublicKey:
+        return _FakePublicKey()
+
+    def signer(self) -> _FakeSigner:
+        return _FakeSigner()
+
+
+@pytest.mark.asyncio
+async def test_emissions_worker_and_reputer_paths_forward_queue_options() -> None:
+    """Verify emissions tx helpers forward queue options to TxManager."""
+    tx_manager = SimpleNamespace(
+        wallet=_FakeWallet(),
+        submit_transaction=AsyncMock(return_value=object()),
+        simulate_transaction=AsyncMock(),
+    )
+    txs = EmissionsTxs(txs=cast(TxManager, tx_manager))
+    deadline = datetime.now() + timedelta(seconds=30)
+
+    await txs.insert_worker_payload(
+        topic_id=1,
+        inference_value="1.23",
+        nonce=100,
+        use_queue=True,
+        queue_priority=80,
+        queue_deadline_at=deadline,
+        fee_tier=FeeTier.PRIORITY,
+    )
+    await txs.delegate_stake(
+        sender="allo1sender",
+        topic_id=1,
+        reputer="allo1reputer",
+        amount="1000",
+        use_queue=True,
+        queue_priority=40,
+        queue_deadline_at=deadline,
+    )
+
+    first_kwargs = tx_manager.submit_transaction.await_args_list[0].kwargs
+    second_kwargs = tx_manager.submit_transaction.await_args_list[1].kwargs
+
+    assert first_kwargs["use_queue"] is True
+    assert first_kwargs["queue_priority"] == 80
+    assert first_kwargs["queue_deadline_at"] == deadline
+    assert second_kwargs["use_queue"] is True
+    assert second_kwargs["queue_priority"] == 40
+    assert second_kwargs["queue_deadline_at"] == deadline

--- a/tests/test_tx_manager_queue_unit.py
+++ b/tests/test_tx_manager_queue_unit.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 from typing import Any, cast
@@ -7,7 +8,14 @@ import pytest
 
 from allora_sdk.rpc_client.client_emissions import EmissionsTxs
 from allora_sdk.rpc_client.config import AlloraNetworkConfig
-from allora_sdk.rpc_client.tx_manager import FeeTier, PendingTx, TxManager
+from allora_sdk.rpc_client.tx_manager import (
+    AccountSequenceMismatchError,
+    FeeTier,
+    InsufficientFeesError,
+    OutOfGasError,
+    PendingTx,
+    TxManager,
+)
 
 
 def _make_tx_manager() -> TxManager:
@@ -148,3 +156,110 @@ async def test_emissions_worker_and_reputer_paths_forward_queue_options() -> Non
     assert second_kwargs["use_queue"] is True
     assert second_kwargs["queue_priority"] == 40
     assert second_kwargs["queue_deadline_at"] == deadline
+
+
+@pytest.mark.asyncio
+async def test_queue_submit_increases_gas_multiplier_across_retries() -> None:
+    """Verify queue retries increase gas multiplier after previous failures."""
+    manager = _make_tx_manager()
+    manager._pre_flight_checks = AsyncMock()  # type: ignore[method-assign]
+    manager._build_and_broadcast = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            OutOfGasError("out-of-gas"),
+            ("tx-hash", 123, cast(Any, object())),
+        ]
+    )
+    manager.wait_for_tx = AsyncMock(return_value=SimpleNamespace(tx_response=SimpleNamespace(code=0, txhash="ok")))  # type: ignore[method-assign]
+    manager._log_tx_response = Mock()  # type: ignore[method-assign]
+    manager._raise_for_status = Mock()  # type: ignore[method-assign]
+    payload = cast(
+        Any,
+        SimpleNamespace(
+            type_url="/emissions.v9.InsertWorkerPayloadRequest",
+            msgs=[],
+            gas_limit=100,
+            fee_tier=FeeTier.STANDARD,
+            retry_attempt=0,
+            fee_multiplier_override=None,
+        ),
+    )
+
+    with pytest.raises(OutOfGasError):
+        await manager._submit_via_queue(payload, sequence=7)  # type: ignore[arg-type]
+
+    assert payload.retry_attempt == 1
+    await manager._submit_via_queue(payload, sequence=7)  # type: ignore[arg-type]
+
+    first_call = manager._build_and_broadcast.await_args_list[0]
+    second_call = manager._build_and_broadcast.await_args_list[1]
+    assert first_call.kwargs["gas_multiplier"] == 1.0
+    assert second_call.kwargs["gas_multiplier"] == 1.3
+
+
+@pytest.mark.asyncio
+async def test_queue_submit_invalidates_gas_cache_and_escalates_fee_on_insufficient_fees() -> None:
+    """Verify insufficient-fee retries clear gas cache and adjust fee multiplier."""
+    manager = _make_tx_manager()
+    manager._cached_gas_price = Decimal("42")
+    manager._gas_price_cache_time = datetime.now()
+    manager._pre_flight_checks = AsyncMock()  # type: ignore[method-assign]
+    manager._build_and_broadcast = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            InsufficientFeesError("insufficient"),
+            ("tx-hash", 123, cast(Any, object())),
+        ]
+    )
+    manager.wait_for_tx = AsyncMock(return_value=SimpleNamespace(tx_response=SimpleNamespace(code=0, txhash="ok")))  # type: ignore[method-assign]
+    manager._log_tx_response = Mock()  # type: ignore[method-assign]
+    manager._raise_for_status = Mock()  # type: ignore[method-assign]
+    payload = cast(
+        Any,
+        SimpleNamespace(
+            type_url="/emissions.v9.InsertWorkerPayloadRequest",
+            msgs=[],
+            gas_limit=100,
+            fee_tier=FeeTier.STANDARD,
+            retry_attempt=0,
+            fee_multiplier_override=None,
+        ),
+    )
+
+    with pytest.raises(InsufficientFeesError):
+        await manager._submit_via_queue(payload, sequence=7)  # type: ignore[arg-type]
+
+    assert manager._cached_gas_price is None
+    assert manager._gas_price_cache_time is None
+    assert payload.fee_multiplier_override == 1.0
+    assert payload.retry_attempt == 1
+
+    await manager._submit_via_queue(payload, sequence=7)  # type: ignore[arg-type]
+
+    first_call = manager._build_and_broadcast.await_args_list[0]
+    second_call = manager._build_and_broadcast.await_args_list[1]
+    assert first_call.args[3] == manager._fee_multipliers[FeeTier.STANDARD]
+    assert second_call.args[3] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_queue_submit_refetches_sequence_after_sequence_mismatch() -> None:
+    """Verify queue mode invalidates and refetches sequence after mismatch."""
+    manager = _make_tx_manager()
+    manager._fetch_account_sequence = AsyncMock(return_value=5)  # type: ignore[method-assign]
+    manager._submit_via_queue = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            AccountSequenceMismatchError("mismatch"),
+            SimpleNamespace(code=0, txhash="ok"),
+        ]
+    )
+
+    pending = await manager.submit_transaction(
+        type_url="/emissions.v9.InsertWorkerPayloadRequest",
+        msgs=[],
+        use_queue=True,
+        max_retries=2,
+    )
+    result = await pending
+
+    assert result.txhash == "ok"
+    assert manager._fetch_account_sequence.await_count == 2
+    await manager.close(cancel_pending_queue=False)

--- a/tests/test_tx_queue_unit.py
+++ b/tests/test_tx_queue_unit.py
@@ -156,6 +156,52 @@ async def test_ordering_deadline_then_priority_then_fifo() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fifo_ordering_with_identical_created_at_uses_enqueue_sequence() -> None:
+    adapter = FakeAdapter()
+    fixed_now = datetime(2026, 1, 1, 0, 0, 0)
+    queue = TransactionQueue[str, str](adapter, now_fn=lambda: fixed_now)
+    await queue.start()
+
+    first = await queue.enqueue(request_id="r1", account_id="acc1", payload="p1", priority=10)
+    second = await queue.enqueue(request_id="r2", account_id="acc2", payload="p2", priority=10)
+    third = await queue.enqueue(request_id="r3", account_id="acc3", payload="p3", priority=10)
+
+    await asyncio.gather(first, second, third)
+
+    payload_order = [payload for payload, _ in adapter.submit_calls]
+    assert payload_order == ["p1", "p2", "p3"]
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_sort_key_includes_sequence_number_for_deterministic_ties() -> None:
+    adapter = FakeAdapter()
+    fixed_now = datetime(2026, 1, 1, 0, 0, 0)
+    queue = TransactionQueue[str, str](adapter, now_fn=lambda: fixed_now)
+    handle = tx_queue_module.PendingQueueTx[str]()
+    item = tx_queue_module.QueueItem[str, str](
+        request_id="r1",
+        account_id="acc1",
+        payload="p1",
+        priority=10,
+        deadline_at=None,
+        max_retries=0,
+        timeout=None,
+        metadata={},
+        created_at=fixed_now,
+        handle=handle,
+    )
+
+    sort_key_0 = queue._compute_sort_key(item, 0)
+    sort_key_1 = queue._compute_sort_key(item, 1)
+
+    assert sort_key_0[:-1] == sort_key_1[:-1]
+    assert sort_key_0[-1] == 0
+    assert sort_key_1[-1] == 1
+    assert sort_key_0 < sort_key_1
+
+
+@pytest.mark.asyncio
 async def test_same_account_is_strictly_sequential() -> None:
     adapter = FakeAdapter()
     adapter.submit_delays["p1"] = 0.05

--- a/tests/test_tx_queue_unit.py
+++ b/tests/test_tx_queue_unit.py
@@ -92,6 +92,7 @@ class FakeAdapter:
 
 @pytest.mark.asyncio
 async def test_enqueue_requires_start() -> None:
+    """Verify enqueue fails if queue has not been started."""
     adapter = FakeAdapter()
     queue = TransactionQueue[str, str](adapter)
     with pytest.raises(TxQueueNotStartedError):
@@ -100,6 +101,7 @@ async def test_enqueue_requires_start() -> None:
 
 @pytest.mark.asyncio
 async def test_queue_stops_and_rejects_new_work() -> None:
+    """Verify enqueue fails after queue has been stopped."""
     adapter = FakeAdapter()
     queue = TransactionQueue[str, str](adapter)
     await queue.start()
@@ -110,6 +112,7 @@ async def test_queue_stops_and_rejects_new_work() -> None:
 
 @pytest.mark.asyncio
 async def test_negative_max_retries_is_rejected() -> None:
+    """Verify max_retries validation rejects negative values."""
     adapter = FakeAdapter()
     queue = TransactionQueue[str, str](adapter)
     await queue.start()
@@ -120,6 +123,7 @@ async def test_negative_max_retries_is_rejected() -> None:
 
 @pytest.mark.asyncio
 async def test_priority_is_clamped() -> None:
+    """Verify priorities are clamped to configured min/max bounds."""
     adapter = FakeAdapter()
     queue = TransactionQueue[str, str](adapter, min_priority=0, max_priority=100)
     await queue.start()
@@ -137,6 +141,7 @@ async def test_priority_is_clamped() -> None:
 
 @pytest.mark.asyncio
 async def test_ordering_deadline_then_priority_then_fifo() -> None:
+    """Verify scheduler orders by deadline, then priority, then FIFO."""
     adapter = FakeAdapter()
     queue = TransactionQueue[str, str](adapter)
     await queue.start()
@@ -157,6 +162,7 @@ async def test_ordering_deadline_then_priority_then_fifo() -> None:
 
 @pytest.mark.asyncio
 async def test_fifo_ordering_with_identical_created_at_uses_enqueue_sequence() -> None:
+    """Verify enqueue sequence breaks ties when timestamps are identical."""
     adapter = FakeAdapter()
     fixed_now = datetime(2026, 1, 1, 0, 0, 0)
     queue = TransactionQueue[str, str](adapter, now_fn=lambda: fixed_now)
@@ -175,6 +181,7 @@ async def test_fifo_ordering_with_identical_created_at_uses_enqueue_sequence() -
 
 @pytest.mark.asyncio
 async def test_sort_key_includes_sequence_number_for_deterministic_ties() -> None:
+    """Verify sort key appends sequence number for deterministic ordering."""
     adapter = FakeAdapter()
     fixed_now = datetime(2026, 1, 1, 0, 0, 0)
     queue = TransactionQueue[str, str](adapter, now_fn=lambda: fixed_now)
@@ -203,6 +210,7 @@ async def test_sort_key_includes_sequence_number_for_deterministic_ties() -> Non
 
 @pytest.mark.asyncio
 async def test_same_account_is_strictly_sequential() -> None:
+    """Verify same-account transactions never execute concurrently."""
     adapter = FakeAdapter()
     adapter.submit_delays["p1"] = 0.05
     adapter.submit_delays["p2"] = 0.01
@@ -224,6 +232,7 @@ async def test_same_account_is_strictly_sequential() -> None:
 
 @pytest.mark.asyncio
 async def test_different_accounts_can_progress_concurrently() -> None:
+    """Verify different accounts can make progress in parallel."""
     adapter = FakeAdapter()
     adapter.submit_delays["p1"] = 0.05
     adapter.submit_delays["p2"] = 0.05
@@ -242,6 +251,7 @@ async def test_different_accounts_can_progress_concurrently() -> None:
 
 @pytest.mark.asyncio
 async def test_sequence_mismatch_invalidates_and_refetches_sequence() -> None:
+    """Verify sequence mismatch triggers invalidation and refetch before retry."""
     adapter = FakeAdapter()
     adapter.fetch_sequence_values["a1"] = 7
     adapter.behavior["payload"] = [SequenceMismatchError(), "ok-after-retry"]
@@ -261,6 +271,7 @@ async def test_sequence_mismatch_invalidates_and_refetches_sequence() -> None:
 
 @pytest.mark.asyncio
 async def test_retryable_error_retries_then_succeeds() -> None:
+    """Verify retryable errors are retried and can eventually succeed."""
     adapter = FakeAdapter()
     adapter.behavior["payload"] = [RetryableError(), "ok-final"]
 
@@ -279,6 +290,7 @@ async def test_retryable_error_retries_then_succeeds() -> None:
 
 @pytest.mark.asyncio
 async def test_retry_exhausted_raises_typed_error() -> None:
+    """Verify retry exhaustion raises TxRetryExhaustedError."""
     adapter = FakeAdapter()
     adapter.behavior["payload"] = [RetryableError(), RetryableError(), RetryableError()]
     queue = TransactionQueue[str, str](adapter, retry_backoff_base=0.001, retry_backoff_max=0.001, random_fn=lambda: 0.0)
@@ -291,6 +303,7 @@ async def test_retry_exhausted_raises_typed_error() -> None:
 
 @pytest.mark.asyncio
 async def test_fatal_error_does_not_retry() -> None:
+    """Verify fatal errors fail fast without retry attempts."""
     adapter = FakeAdapter()
     adapter.behavior["payload"] = [FatalError("boom")]
     queue = TransactionQueue[str, str](adapter)
@@ -304,6 +317,7 @@ async def test_fatal_error_does_not_retry() -> None:
 
 @pytest.mark.asyncio
 async def test_expired_classification_maps_to_deadline_error() -> None:
+    """Verify expired classification maps to deadline-exceeded error type."""
     adapter = FakeAdapter()
     adapter.behavior["payload"] = [ExpiredError("expired")]
     queue = TransactionQueue[str, str](adapter)
@@ -316,6 +330,7 @@ async def test_expired_classification_maps_to_deadline_error() -> None:
 
 @pytest.mark.asyncio
 async def test_timeout_retries_with_wait_for() -> None:
+    """Verify timeout handling uses wait_for and retries appropriately."""
     adapter = FakeAdapter()
     adapter.submit_delays["slow"] = 0.03
     queue = TransactionQueue[str, str](adapter, retry_backoff_base=0.001, retry_backoff_max=0.001, random_fn=lambda: 0.0)
@@ -335,6 +350,7 @@ async def test_timeout_retries_with_wait_for() -> None:
 
 @pytest.mark.asyncio
 async def test_deadline_exceeded_before_processing() -> None:
+    """Verify items past deadline fail before submission starts."""
     adapter = FakeAdapter()
     queue = TransactionQueue[str, str](adapter)
     await queue.start()
@@ -351,6 +367,7 @@ async def test_deadline_exceeded_before_processing() -> None:
 
 @pytest.mark.asyncio
 async def test_stop_cancel_pending_marks_queued_items() -> None:
+    """Verify stop(cancel_pending=True) fails inflight and queued items."""
     adapter = FakeAdapter()
     adapter.submit_delays["slow"] = 0.1
     queue = TransactionQueue[str, str](adapter)
@@ -369,6 +386,7 @@ async def test_stop_cancel_pending_marks_queued_items() -> None:
 
 @pytest.mark.asyncio
 async def test_stop_without_cancel_pending_drains_inflight_and_queued() -> None:
+    """Verify stop(cancel_pending=False) drains outstanding work to completion."""
     adapter = FakeAdapter()
     adapter.submit_delays["slow"] = 0.02
     queue = TransactionQueue[str, str](adapter)

--- a/tests/test_tx_queue_unit.py
+++ b/tests/test_tx_queue_unit.py
@@ -1,0 +1,340 @@
+import asyncio
+import importlib.util
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+TX_QUEUE_PATH = Path(__file__).resolve().parents[1] / "src" / "allora_sdk" / "rpc_client" / "tx_queue.py"
+TX_QUEUE_SPEC = importlib.util.spec_from_file_location("tx_queue_module", TX_QUEUE_PATH)
+if TX_QUEUE_SPEC is None or TX_QUEUE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load tx_queue module from {TX_QUEUE_PATH}")
+tx_queue_module = importlib.util.module_from_spec(TX_QUEUE_SPEC)
+sys.modules[TX_QUEUE_SPEC.name] = tx_queue_module
+TX_QUEUE_SPEC.loader.exec_module(tx_queue_module)
+
+ErrorClassification = tx_queue_module.ErrorClassification
+TransactionQueue = tx_queue_module.TransactionQueue
+TxDeadlineExceededError = tx_queue_module.TxDeadlineExceededError
+TxQueueNotStartedError = tx_queue_module.TxQueueNotStartedError
+TxQueueStoppedError = tx_queue_module.TxQueueStoppedError
+TxRetryExhaustedError = tx_queue_module.TxRetryExhaustedError
+
+
+class RetryableError(Exception):
+    pass
+
+
+class SequenceMismatchError(Exception):
+    pass
+
+
+class FatalError(Exception):
+    pass
+
+
+class ExpiredError(Exception):
+    pass
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.fetch_sequence_calls: List[str] = []
+        self.fetch_sequence_values: Dict[str, int] = defaultdict(int)
+        self.submit_calls: List[tuple[str, int]] = []
+        self.submit_start_times: Dict[str, float] = {}
+        self.submit_end_times: Dict[str, float] = {}
+        self.submit_delays: Dict[str, float] = {}
+        self.behavior: Dict[str, List[Any]] = defaultdict(list)
+        self.result_prefix = "ok"
+
+    async def fetch_sequence(self, account_id: str) -> int:
+        self.fetch_sequence_calls.append(account_id)
+        return self.fetch_sequence_values[account_id]
+
+    async def submit(self, payload: str, sequence: Optional[int]) -> str:
+        assert sequence is not None
+        now = asyncio.get_running_loop().time()
+        self.submit_start_times[payload] = now
+        if payload in self.submit_delays and self.submit_delays[payload] > 0:
+            await asyncio.sleep(self.submit_delays[payload])
+        self.submit_calls.append((payload, sequence))
+
+        outcomes = self.behavior.get(payload, [])
+        if outcomes:
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                self.submit_end_times[payload] = asyncio.get_running_loop().time()
+                raise outcome
+            self.submit_end_times[payload] = asyncio.get_running_loop().time()
+            return str(outcome)
+
+        self.submit_end_times[payload] = asyncio.get_running_loop().time()
+        return f"{self.result_prefix}:{payload}:{sequence}"
+
+    def classify_error(self, err: Exception) -> ErrorClassification:
+        if isinstance(err, RetryableError):
+            return ErrorClassification.RETRYABLE
+        if isinstance(err, SequenceMismatchError):
+            return ErrorClassification.SEQUENCE_MISMATCH
+        if isinstance(err, ExpiredError):
+            return ErrorClassification.EXPIRED
+        if isinstance(err, asyncio.TimeoutError):
+            return ErrorClassification.RETRYABLE
+        return ErrorClassification.FATAL
+
+    def is_timeout(self, err: Exception) -> bool:
+        return isinstance(err, asyncio.TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_requires_start() -> None:
+    adapter = FakeAdapter()
+    queue = TransactionQueue[str, str](adapter)
+    with pytest.raises(TxQueueNotStartedError):
+        await queue.enqueue(request_id="r1", account_id="a1", payload="p1")
+
+
+@pytest.mark.asyncio
+async def test_queue_stops_and_rejects_new_work() -> None:
+    adapter = FakeAdapter()
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+    await queue.stop()
+    with pytest.raises(TxQueueStoppedError):
+        await queue.enqueue(request_id="r1", account_id="a1", payload="p1")
+
+
+@pytest.mark.asyncio
+async def test_negative_max_retries_is_rejected() -> None:
+    adapter = FakeAdapter()
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+    with pytest.raises(ValueError):
+        await queue.enqueue(request_id="r1", account_id="a1", payload="p1", max_retries=-1)
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_priority_is_clamped() -> None:
+    adapter = FakeAdapter()
+    queue = TransactionQueue[str, str](adapter, min_priority=0, max_priority=100)
+    await queue.start()
+
+    low = await queue.enqueue(request_id="r-low", account_id="a1", payload="low", priority=-99)
+    high = await queue.enqueue(request_id="r-high", account_id="a2", payload="high", priority=999)
+
+    low_result = await low
+    high_result = await high
+
+    assert low_result == "ok:low:0"
+    assert high_result == "ok:high:0"
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_ordering_deadline_then_priority_then_fifo() -> None:
+    adapter = FakeAdapter()
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+
+    soon = datetime.now() + timedelta(seconds=60)
+    later = datetime.now() + timedelta(seconds=120)
+
+    h1 = await queue.enqueue(request_id="r1", account_id="acc1", payload="p1", priority=1, deadline_at=later)
+    h2 = await queue.enqueue(request_id="r2", account_id="acc2", payload="p2", priority=50, deadline_at=soon)
+    h3 = await queue.enqueue(request_id="r3", account_id="acc3", payload="p3", priority=50)
+    h4 = await queue.enqueue(request_id="r4", account_id="acc4", payload="p4", priority=50)
+
+    await asyncio.gather(h1, h2, h3, h4)
+    payload_order = [payload for payload, _ in adapter.submit_calls]
+    assert payload_order == ["p2", "p1", "p3", "p4"]
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_same_account_is_strictly_sequential() -> None:
+    adapter = FakeAdapter()
+    adapter.submit_delays["p1"] = 0.05
+    adapter.submit_delays["p2"] = 0.01
+
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+
+    h1 = await queue.enqueue(request_id="r1", account_id="same", payload="p1", priority=10)
+    h2 = await queue.enqueue(request_id="r2", account_id="same", payload="p2", priority=90)
+
+    await asyncio.gather(h1, h2)
+    p1_window = (adapter.submit_start_times["p1"], adapter.submit_end_times["p1"])
+    p2_window = (adapter.submit_start_times["p2"], adapter.submit_end_times["p2"])
+    no_overlap = p1_window[1] <= p2_window[0] or p2_window[1] <= p1_window[0]
+    assert no_overlap
+    assert sorted(seq for _, seq in adapter.submit_calls) == [0, 1]
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_different_accounts_can_progress_concurrently() -> None:
+    adapter = FakeAdapter()
+    adapter.submit_delays["p1"] = 0.05
+    adapter.submit_delays["p2"] = 0.05
+
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+
+    h1 = await queue.enqueue(request_id="r1", account_id="a1", payload="p1", priority=1)
+    h2 = await queue.enqueue(request_id="r2", account_id="a2", payload="p2", priority=1)
+
+    await asyncio.gather(h1, h2)
+    delta = abs(adapter.submit_start_times["p1"] - adapter.submit_start_times["p2"])
+    assert delta < 0.03
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_sequence_mismatch_invalidates_and_refetches_sequence() -> None:
+    adapter = FakeAdapter()
+    adapter.fetch_sequence_values["a1"] = 7
+    adapter.behavior["payload"] = [SequenceMismatchError(), "ok-after-retry"]
+
+    queue = TransactionQueue[str, str](adapter, retry_backoff_base=0.001, retry_backoff_max=0.001, random_fn=lambda: 0.0)
+    await queue.start()
+
+    handle = await queue.enqueue(request_id="r1", account_id="a1", payload="payload", max_retries=2)
+    result = await handle
+
+    assert result == "ok-after-retry"
+    assert adapter.fetch_sequence_calls == ["a1", "a1"]
+    assert adapter.submit_calls[0] == ("payload", 7)
+    assert adapter.submit_calls[1] == ("payload", 7)
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_retryable_error_retries_then_succeeds() -> None:
+    adapter = FakeAdapter()
+    adapter.behavior["payload"] = [RetryableError(), "ok-final"]
+
+    queue = TransactionQueue[str, str](adapter, retry_backoff_base=0.001, retry_backoff_max=0.001, random_fn=lambda: 0.0)
+    await queue.start()
+
+    handle = await queue.enqueue(request_id="r1", account_id="a1", payload="payload", max_retries=2)
+    result = await handle
+
+    assert result == "ok-final"
+    assert len(adapter.submit_calls) == 2
+    assert adapter.submit_calls[0][1] == 0
+    assert adapter.submit_calls[1][1] == 0
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausted_raises_typed_error() -> None:
+    adapter = FakeAdapter()
+    adapter.behavior["payload"] = [RetryableError(), RetryableError(), RetryableError()]
+    queue = TransactionQueue[str, str](adapter, retry_backoff_base=0.001, retry_backoff_max=0.001, random_fn=lambda: 0.0)
+    await queue.start()
+    handle = await queue.enqueue(request_id="r1", account_id="a1", payload="payload", max_retries=2)
+    with pytest.raises(TxRetryExhaustedError):
+        await handle
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_fatal_error_does_not_retry() -> None:
+    adapter = FakeAdapter()
+    adapter.behavior["payload"] = [FatalError("boom")]
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+    handle = await queue.enqueue(request_id="r1", account_id="a1", payload="payload", max_retries=3)
+    with pytest.raises(FatalError):
+        await handle
+    assert len(adapter.submit_calls) == 1
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_expired_classification_maps_to_deadline_error() -> None:
+    adapter = FakeAdapter()
+    adapter.behavior["payload"] = [ExpiredError("expired")]
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+    handle = await queue.enqueue(request_id="r1", account_id="a1", payload="payload", max_retries=3)
+    with pytest.raises(TxDeadlineExceededError, match="Expired request r1"):
+        await handle
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_timeout_retries_with_wait_for() -> None:
+    adapter = FakeAdapter()
+    adapter.submit_delays["slow"] = 0.03
+    queue = TransactionQueue[str, str](adapter, retry_backoff_base=0.001, retry_backoff_max=0.001, random_fn=lambda: 0.0)
+    await queue.start()
+    handle = await queue.enqueue(
+        request_id="r1",
+        account_id="a1",
+        payload="slow",
+        timeout=timedelta(milliseconds=5),
+        max_retries=1,
+    )
+    with pytest.raises(TxRetryExhaustedError):
+        await handle
+    assert len(adapter.submit_calls) == 0
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_deadline_exceeded_before_processing() -> None:
+    adapter = FakeAdapter()
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+    handle = await queue.enqueue(
+        request_id="r1",
+        account_id="a1",
+        payload="payload",
+        deadline_at=datetime.now() - timedelta(milliseconds=1),
+    )
+    with pytest.raises(TxDeadlineExceededError):
+        await handle
+    await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancel_pending_marks_queued_items() -> None:
+    adapter = FakeAdapter()
+    adapter.submit_delays["slow"] = 0.1
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+
+    running = await queue.enqueue(request_id="r1", account_id="a1", payload="slow")
+    pending = await queue.enqueue(request_id="r2", account_id="a1", payload="queued")
+    await asyncio.sleep(0.01)
+    await queue.stop(cancel_pending=True)
+
+    with pytest.raises(TxQueueStoppedError):
+        await running
+    with pytest.raises(TxQueueStoppedError):
+        await pending
+
+
+@pytest.mark.asyncio
+async def test_stop_without_cancel_pending_drains_inflight_and_queued() -> None:
+    adapter = FakeAdapter()
+    adapter.submit_delays["slow"] = 0.02
+    queue = TransactionQueue[str, str](adapter)
+    await queue.start()
+
+    first = await queue.enqueue(request_id="r1", account_id="a1", payload="slow")
+    second = await queue.enqueue(request_id="r2", account_id="a1", payload="queued")
+    third = await queue.enqueue(request_id="r3", account_id="a2", payload="other")
+
+    await asyncio.sleep(0.005)
+    await queue.stop(cancel_pending=False)
+
+    assert await first == "ok:slow:0"
+    assert await second == "ok:queued:1"
+    assert await third == "ok:other:0"


### PR DESCRIPTION
## Purpose
Adds a **Generic Transaction Submission Queue Component** for the Python SDK.

This branch introduces a reusable queue with priority/deadline scheduling, per-account sequential processing, retry handling, and sequence-mismatch recovery (invalidate + refetch). It also adds focused unit tests for ordering, retries, deadline behavior, stop/drain semantics, and same-account vs cross-account execution.

## Goal
Provide a foundation for queue-backed transaction submission while preserving backward compatibility for existing submission paths.

## Properties

Priority-aware scheduling
Optional deadline-based dispatch/fail-fast behavior
Strict per-account sequencing
Sequence cache invalidation + refetch on mismatch
Retry/backoff for retryable failures
Typed queue errors (deadline exceeded, retries exhausted, queue stopped)
Async awaitable result handle
Configurable queue bounds (priority range, backoff, starvation boost)