### PR TITLE
Support sync/async LossFn typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ reputer_custom = AlloraWorker.reputer(
 )
 ```
 
+`loss_fn` can be synchronous or asynchronous. Supported signatures are
+`(ground_truth: float, predicted: float) -> float` and
+`(ground_truth: float, predicted: float) -> Awaitable[float]`.
+
 **Supported Default Loss Methods:**
 
 When `loss_fn` is not provided, the SDK auto-selects from these implementations based on the topic's `loss_method`:

--- a/src/allora_sdk/loss_methods/defaults.py
+++ b/src/allora_sdk/loss_methods/defaults.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Awaitable, Callable, TypeAlias
 
 from .squared_error import squared_error_loss
 from .absolute_error import absolute_error_loss
@@ -9,7 +9,9 @@ from .poisson import poisson_loss
 from .ztae import ztae_loss
 from .zptae import zptae_loss
 
-LossFn = Callable[[float, float], float]
+SyncLossFn: TypeAlias = Callable[[float, float], float]
+AsyncLossFn: TypeAlias = Callable[[float, float], Awaitable[float]]
+LossFn: TypeAlias = SyncLossFn | AsyncLossFn
 
 class UnsupportedLossMethodError(Exception):
     """Raised when a loss_method is not supported by the SDK's default implementations."""


### PR DESCRIPTION
## Summary
- Update LossFn typing to support sync and async callables
- Keep runtime behavior aligned with typing
- Document async loss_fn signature in README

## Test plan
- uv run --group dev pyright src/allora_sdk/loss_methods/defaults.py src/allora_sdk/worker/reputer.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for both synchronous and asynchronous loss functions, improving type clarity and flexibility with no runtime changes. The README now documents the accepted loss_fn signatures.

- **New Features**
  - LossFn is now a TypeAlias union of SyncLossFn and AsyncLossFn.
  - README documents `(ground_truth: float, predicted: float) -> float` and `(ground_truth: float, predicted: float) -> Awaitable[float]`.

<sup>Written for commit 688b2f4c55c64218efc7c927516174cf5ae4a1c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

