### PR TITLE
Improve worker callback error logging

### DIFF
--- a/example_forecaster.py
+++ b/example_forecaster.py
@@ -1,5 +1,9 @@
 import asyncio
+import logging
 from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker
+
+logger = logging.getLogger(__name__)
+
 
 def run_model(nonce: int) -> dict[str, float]:
     return {
@@ -16,6 +20,7 @@ async def main():
 
     async for result in worker.run():
         if isinstance(result, Exception):
+            logger.error("Forecaster worker error: %s", result)
             continue
         print(f"Forecast submitted to Allora: {result.submission}")
 

--- a/example_inference_worker.py
+++ b/example_inference_worker.py
@@ -1,5 +1,9 @@
 import asyncio
+import logging
 from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker
+
+logger = logging.getLogger(__name__)
+
 
 def run_model(nonce: int):
     return 10
@@ -14,6 +18,7 @@ async def main():
 
     async for result in worker.run():
         if isinstance(result, Exception):
+            logger.error("Inference worker error: %s", result)
             continue
         print(f"Prediction submitted to Allora: {result.submission}")
 

--- a/example_inference_worker.py
+++ b/example_inference_worker.py
@@ -18,7 +18,7 @@ async def main():
 
     async for result in worker.run():
         if isinstance(result, Exception):
-            logger.error("Inference worker error: %s", result)
+            logger.error("Inference worker error", exc_info=result)
             continue
         print(f"Prediction submitted to Allora: {result.submission}")
 

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -124,7 +124,7 @@ class Forecaster:
 
             forecasts_raw = await resolve_maybe_awaitable(self.forecast_fn, nonce)
         except Exception as err:
-            logger.debug(f"Forecast function failed: {err}")
+            logger.error("Forecast function failed", exc_info=True)
             return err
 
         try:

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -154,7 +154,7 @@ class Inferer:
 
             prediction = await resolve_maybe_awaitable(self.predict_fn, nonce)
         except Exception as err:
-            logger.debug(f"Prediction function failed: {err}")
+            logger.error("Prediction function failed", exc_info=True)
             return err
 
         # Sanity check prediction against network consensus (throttled; see SanityCheckConfig)

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -670,7 +670,10 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
                     logger.error(f"⚠️ Transaction timed out: topic_id={self.topic_id} nonce={nonce}")
 
                 elif isinstance(result, Exception):
-                    logger.error(f"❌ Unknown error submitting for nonce {nonce}: {str(result)} {type(result)}")
+                    logger.error(
+                        f"❌ Unknown error submitting for nonce {nonce}: {str(result)} {type(result)}",
+                        exc_info=(type(result), result, result.__traceback__),
+                    )
                     self.submitted_nonces.add(nonce)
 
                 elif result:


### PR DESCRIPTION
## Summary
- Log user callback failures at error level with traceback
- Include traceback context in pipeline-level unknown error logs
- Update examples to log exceptions instead of silently continuing

## Test plan
- Manual review of logging paths in inferer/forecaster/worker
- Lint check on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve error logging for worker callbacks with full tracebacks so failures are easier to debug. Example workers now log errors.

- **Bug Fixes**
  - Log forecast and prediction callback failures at error level with traceback (exc_info=True).
  - Include traceback for unknown errors during submit using exc_info with the original exception.
  - Update example forecaster and inference workers to use logging; inference example logs traceback.

<sup>Written for commit 205443e7a9a268f7d8f33f7afd8528dacd1dfc52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

