### PR TITLE
Change callback API to use contexts, reputer_fn, and various small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,27 @@ Submits predictions to Allora Network topics with your ML models. The worker han
 
 The simplest way to start participating in the Allora network is to paste the following snippet into a Jupyter or Google Colab notebook (or just a Python file that you can run from your terminal).  It will automatically handle all of the network onboarding and configuration behind the scenes, and will start submitting inferences automatically.
 
-**NOTE:** you will need an Allora API key.  You can obtain one for free at [https://developer.allora.network](https://developer.allora.network).
+A slightly more complete example can be found in the file `example_inference_worker.py`.
 
 ```python
-from allora_sdk import AlloraWorker
+from allora_sdk import AlloraNetworkConfig, AlloraWorker, RunContext
 
-def my_model():
-    # Your ML model prediction logic
-    return 120000.0  # Example BTC price prediction
+async def run_model(context: RunContext) -> float:
+    # your ML model prediction logic
+    return 123.45
 
 async def main():
-    worker = AlloraWorker.testnet(
-        run=my_model,
-        api_key="<YOUR API KEY HERE>",
+    worker = AlloraWorker.inferer(
+        topic_id=69,
+        network=AlloraNetworkConfig.testnet(),
+        run=run_model,
     )
-    
+
     async for result in worker.run():
         if isinstance(result, Exception):
-            print(f"Error: {result}")
+            print(f"Inference worker error: {result}")
         else:
-            print(f"Prediction submitted: {result.prediction}")
+            print(f"Prediction submitted to Allora: {result.submission}")
 
 # IF YOU'RE RUNNING IN A PYTHON FILE:
 import asyncio
@@ -159,80 +160,43 @@ inference_worker = AlloraWorker.inferer(
 
 ### Reputer Configuration
 
-Reputers evaluate inference quality by computing losses between ground truth and predictions. The SDK supports automatic loss function selection based on the topic's on-chain configuration.
+Reputers evaluate inference quality by computing losses between ground truth and predictions. An simple reputer can be built with the SDK just as easily as an inference worker. The main difference, is that instead of the `run_model` callback we need to pass a `reputer_fn` which has the type `(context: RunContext, inference: float) -> float`. This function gets called once for each inference in the epoch (that is, the network inference, each individual worker's inference, and a few additional "one-out" inferences which the network uses for scoring). It is expected to obtain a ground truth value, compare it to the inference, and return a loss which is computed with the topic-defined loss function. 
+
+In practice, it is often more convenient to have two separate callbacks:
+1. A ground truth function `get_ground_truth(context: RunContext) -> GroundTruthType` which only runs once per epoch.
+2. A loss function `loss(inference: float, gt: GroundTruthType) -> float`, which runs for every value in the inference bundle
+
+Note that the ground truth type does not need to agree with the inference type (`float`). That is useful for certain loss functions which require extra data. For example, the `czar` and `ztae` loss functions require a standard deviation of historical values, which can just be treated as part of the ground truth.
+
+We provide a helper function `make_reputer_function` which takes two functions `get_ground_truth` and `loss_fn` as above and returns a `reputer_fn` that is suitable for passing to the Allora worker. It handles the caching of the ground truth, so that `get_ground_truth` only needs to be called once.
 
 ```python
-from allora_sdk.worker import AlloraWorker
+def mse_loss(x: float, y: float) -> float:
+    return (x-y)**2
 
-async def get_ground_truth(nonce: int) -> float:
-    # Return the actual value for the given epoch/nonce
-    return 100.0
+async def get_ground_truth(context: RunContext) -> float:
+    nonce_time = await get_block_time(context.client, context.nonce)
+    prediction_time = nonce_time.replace(second=0, microsecond=0) + timedelta(days = 1)
 
-# Simplest reputer setup - loss function auto-selected based on topic config
-reputer = AlloraWorker.reputer(
-    ground_truth_fn=get_ground_truth,
-    topic_id=1,
-    api_key="UP-...",
-)
+    logger.info(f'Generating ground truth for epoch starting at {nonce_time}')
+    logger.info(f'As this is a 1 day BTC/USD price prediction topic, we need to get the price of BTC at {prediction_time}')
 
-# Custom loss function example
-def my_custom_loss(ground_truth: float, predicted: float) -> float:
-    return abs(ground_truth - predicted)  # MAE
+    # getting this from some data source
+    ground_truth = 123.45
 
-reputer_custom = AlloraWorker.reputer(
-    ground_truth_fn=get_ground_truth,
-    loss_fn=my_custom_loss,  # Override auto-selection
-    topic_id=1,
-    api_key="UP-...",
+    return ground_truth
+
+# ...
+
+worker = AlloraWorker.reputer(
+    topic_id=69,
+    network=AlloraNetworkConfig.testnet(),
+    reputer_fn=make_reputer_function(get_ground_truth, mse_loss),
+    min_stake_uallo=1_000_000,
 )
 ```
 
-`loss_fn` can be synchronous or asynchronous. Supported signatures are
-`(ground_truth: float, predicted: float) -> float` and
-`(ground_truth: float, predicted: float) -> Awaitable[float]`.
-
-**Supported Default Loss Methods:**
-
-When `loss_fn` is not provided, the SDK auto-selects from these implementations based on the topic's `loss_method`:
-
-| Method | Aliases | Description |
-|--------|---------|-------------|
-| `sqe` | `mse`, `squared_error` | Squared Error |
-| `abse` | `mae`, `absolute_error` | Absolute Error |
-| `huber` | - | Huber Loss (delta=1.0) |
-| `logcosh` | `log_cosh` | Log-Cosh Loss |
-| `bce` | `binary_cross_entropy` | Binary Cross Entropy |
-| `poisson` | - | Poisson Loss |
-| `ztae` | - | Z-Transformed Absolute Error* |
-| `zptae` | - | Z Power-Tanh Absolute Error* |
-
-*Note: `ztae` and `zptae` require a standard deviation (std) parameter. The default functions use std=1.0. For proper use, create custom functions with `make_ztae_loss(std=...)` or `make_zptae_loss(std=...)`.
-
-You can also use these loss functions directly:
-
-```python
-from allora_sdk.loss_methods import (
-    get_default_loss_fn,
-    squared_error_loss,
-    absolute_error_loss,
-    huber_loss,
-    make_ztae_loss,
-    make_zptae_loss,
-)
-
-# Get by name
-loss_fn = get_default_loss_fn("mse")
-
-# Or use directly
-loss = squared_error_loss(ground_truth=100.0, predicted=95.0)  # Returns 25.0
-
-# For ztae/zptae, create with your data's std:
-ztae = make_ztae_loss(std=0.02)  # std = historical volatility
-loss = ztae(ground_truth=0.01, predicted=0.02)
-
-zptae = make_zptae_loss(std=0.02, alpha=0.25, beta=2.0)
-loss = zptae(ground_truth=0.01, predicted=0.02)
-```
+A full example is in `example_reputer.py`.
 
 ## Allora RPC Client
 

--- a/example_forecaster.py
+++ b/example_forecaster.py
@@ -9,6 +9,9 @@ async def run_model(ctx: RunContext) -> dict[str, float]:
     # get inferers who participated in the previous epoch
     epoch_length = 54
     value_bundle = await get_network_inference(ctx.client, ctx.topic_id, ctx.nonce - epoch_length)
+    if value_bundle is None:
+        return {}
+
     inferer_addrs = [x.worker for x in value_bundle.inferer_values]
 
     # predict loss for each inferer

--- a/example_forecaster.py
+++ b/example_forecaster.py
@@ -1,19 +1,25 @@
 import asyncio
 import logging
-from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker
+from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker, RunContext, ValueBundle, get_network_inference
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
+async def run_model(ctx: RunContext) -> dict[str, float]:
+    # get inferers who participated in the previous epoch
+    epoch_length = 54
+    value_bundle = await get_network_inference(ctx.client, ctx.topic_id, ctx.nonce - epoch_length)
+    inferer_addrs = [x.worker for x in value_bundle.inferer_values]
 
-def run_model(nonce: int) -> dict[str, float]:
-    return {
-        "allo1inferer1...": 10.0,
-    }
+    # predict loss for each inferer
+    forecast = {addr: 1.23 for addr in inferer_addrs}
+
+    return forecast
 
 async def main():
     worker = AlloraWorker.forecaster(
         topic_id=69,
-        wallet=AlloraWalletConfig(mnemonic="..."),
+        # wallet=AlloraWalletConfig(mnemonic="..."),  # uncomment to use a specific wallet instead of generating one
         network=AlloraNetworkConfig.testnet(),
         run=run_model,
     )

--- a/example_inference_worker.py
+++ b/example_inference_worker.py
@@ -1,17 +1,27 @@
 import asyncio
 import logging
-from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker
+from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker, RunContext, get_block_time
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
+async def run_model(context: RunContext) -> float:
+    nonce_time = await get_block_time(context.client, context.nonce)
+    prediction_time = nonce_time.replace(second=0, microsecond=0) + timedelta(days = 1)
 
-def run_model(nonce: int):
-    return 10
+    logger.info(f'Generate prediction for epoch starting at {nonce_time}')
+    logger.info(f'As this is a 1 day BTC/USD price prediction topic, we need to the predict the price of BTC at {prediction_time}')
+
+    # sophisticated machine learning model
+    prediction = 123.45
+
+    return prediction
 
 async def main():
     worker = AlloraWorker.inferer(
         topic_id=69,
-        wallet=AlloraWalletConfig(mnemonic="..."),
+        # wallet=AlloraWalletConfig(mnemonic="..."),  # uncomment to use a specific wallet instead of generating one
         network=AlloraNetworkConfig.testnet(),
         run=run_model,
     )
@@ -20,11 +30,6 @@ async def main():
         if isinstance(result, Exception):
             logger.error("Inference worker error", exc_info=result)
             continue
-        print(f"Prediction submitted to Allora: {result.submission}")
+        logger.info(f"Prediction submitted to Allora: {result.submission}")
 
 asyncio.run(main())
-
-
-
-
-

--- a/example_reputer.py
+++ b/example_reputer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 def mse_loss(x: float, y: float) -> float:
-    return math.log((x-y)**2)   # the Allora chain uses log losses
+    return math.log((x-y)**2 + 1e-12)   # the Allora chain uses log losses
 
 async def get_ground_truth(context: RunContext) -> float:
     nonce_time = await get_block_time(context.client, context.nonce)

--- a/example_reputer.py
+++ b/example_reputer.py
@@ -27,7 +27,7 @@ async def main():
         topic_id=69,
         # wallet=AlloraWalletConfig(mnemonic="..."),  # uncomment to use a specific wallet instead of generating one
         network=AlloraNetworkConfig.testnet(),
-        reputer_fn=make_reputer_function(get_ground_truth, mse_loss),
+        reputer_fn=make_reputer_function(get_ground_truth, mse_loss, log_loss=False),
         min_stake_uallo=1_000_000,
     )
 

--- a/example_reputer.py
+++ b/example_reputer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 def mse_loss(x: float, y: float) -> float:
-    return math.log((x-y)**2 + 1e-12)   # the Allora chain uses log losses
+    return (x-y)**2
 
 async def get_ground_truth(context: RunContext) -> float:
     nonce_time = await get_block_time(context.client, context.nonce)
@@ -27,7 +27,7 @@ async def main():
         topic_id=69,
         # wallet=AlloraWalletConfig(mnemonic="..."),  # uncomment to use a specific wallet instead of generating one
         network=AlloraNetworkConfig.testnet(),
-        reputer_fn=make_reputer_function(get_ground_truth, mse_loss, log_loss=False),
+        reputer_fn=make_reputer_function(get_ground_truth, mse_loss),
         min_stake_uallo=1_000_000,
     )
 

--- a/example_reputer.py
+++ b/example_reputer.py
@@ -1,25 +1,39 @@
 import asyncio
 import logging
-from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker
+import math
+from allora_sdk import AlloraNetworkConfig, AlloraWalletConfig, AlloraWorker, RunContext, make_reputer_function, get_block_time
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
-def get_ground_truth(nonce: int) -> float:
-    return 10.5
+def mse_loss(x: float, y: float) -> float:
+    return math.log((x-y)**2)   # the Allora chain uses log losses
+
+async def get_ground_truth(context: RunContext) -> float:
+    nonce_time = await get_block_time(context.client, context.nonce)
+    prediction_time = nonce_time.replace(second=0, microsecond=0) + timedelta(days = 1)
+
+    logger.info(f'Generating ground truth for epoch starting at {nonce_time}')
+    logger.info(f'As this is a 1 day BTC/USD price prediction topic, we need to get the price of BTC at {prediction_time}')
+
+    # getting this from some data source
+    ground_truth = 123.45
+
+    return ground_truth
 
 async def main():
     worker = AlloraWorker.reputer(
         topic_id=69,
-        wallet=AlloraWalletConfig(mnemonic=""),
+        # wallet=AlloraWalletConfig(mnemonic="..."),  # uncomment to use a specific wallet instead of generating one
         network=AlloraNetworkConfig.testnet(),
-        ground_truth_fn=get_ground_truth,
-        min_stake_uallo=10000000000000000000,
+        reputer_fn=make_reputer_function(get_ground_truth, mse_loss),
+        min_stake_uallo=1_000_000,
     )
 
     async for result in worker.run():
         if isinstance(result, Exception):
             logger.error("Reputer worker error: %s", result)
             continue
-        print(f"Reputer payload submitted to Allora: {result.submission}")
 
 asyncio.run(main())

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -10,7 +10,7 @@ from .loss_methods import (
     UnsupportedLossMethodError,
 )
 from .worker.utils import get_block_time, get_network_inference, make_reputer_function
-from .worker.types import RunContext
+from .worker.context import RunContext
 from cosmpy.aerial.wallet import LocalWallet, PrivateKey
 
 __all__ = [

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,5 +1,6 @@
 from .worker import AlloraWorker
 from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig, TxManager, FeeTier
+from .rpc_client.protos.emissions.v3 import ValueBundle
 from .api_client import AlloraAPIClient
 from .logging_config import setup_sdk_logging
 from .loss_methods import (
@@ -8,6 +9,8 @@ from .loss_methods import (
     SUPPORTED_LOSS_METHODS,
     UnsupportedLossMethodError,
 )
+from .worker.utils import get_block_time, get_network_inference, make_reputer_function
+from .worker.types import RunContext
 from cosmpy.aerial.wallet import LocalWallet, PrivateKey
 
 __all__ = [
@@ -26,4 +29,9 @@ __all__ = [
     "is_supported_loss_method",
     "SUPPORTED_LOSS_METHODS",
     "UnsupportedLossMethodError",
+    "get_block_time",
+    "get_network_inference",
+    "make_reputer_function",
+    "RunContext",
+    "ValueBundle",
 ]

--- a/src/allora_sdk/logging_config.py
+++ b/src/allora_sdk/logging_config.py
@@ -73,7 +73,7 @@ def setup_sdk_logging(debug: bool = False, force: bool = False, use_color: bool 
 
     logging.basicConfig(
         handlers=[handler],
-        force=False
+        force=force
     )
 
     # Configure all SDK loggers explicitly with the requested level

--- a/src/allora_sdk/logging_config.py
+++ b/src/allora_sdk/logging_config.py
@@ -71,12 +71,9 @@ def setup_sdk_logging(debug: bool = False, force: bool = False, use_color: bool 
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
 
-    # Configure root logger with WARNING level to suppress third-party debug logs
-    # The handler has no level filter, so it will output any logs that pass through
     logging.basicConfig(
-        level=logging.WARNING,
         handlers=[handler],
-        force=True
+        force=False
     )
 
     # Configure all SDK loggers explicitly with the requested level
@@ -93,10 +90,9 @@ def setup_sdk_logging(debug: bool = False, force: bool = False, use_color: bool 
         logger = logging.getLogger(logger_name)
         logger.setLevel(sdk_level)
         logger.propagate = True
-    
+
     _LOGGING_CONFIGURED = True
 
 def is_configured() -> bool:
     """Check if SDK logging has been configured."""
     return _LOGGING_CONFIGURED
-

--- a/src/allora_sdk/rpc_client/client_websocket_events.py
+++ b/src/allora_sdk/rpc_client/client_websocket_events.py
@@ -381,7 +381,7 @@ class AlloraWebsocketSubscriber:
                 try:
                     message = await asyncio.wait_for(
                         self.websocket.recv(),
-                        timeout=None
+                        timeout=30,
                     )
                     await self._handle_message(str(message))
                     
@@ -390,9 +390,10 @@ class AlloraWebsocketSubscriber:
                     if not self.websocket.close_code:
                         await self.websocket.ping()
                     continue
-                    
-            except websockets.exceptions.ConnectionClosed:
-                logger.warning("WebSocket connection closed")
+
+            except websockets.exceptions.ConnectionClosed as e:
+                queries = [info.get("query", "?") for info in self.subscriptions.values()]
+                logger.warning(f"WebSocket connection closed: code={e.code} reason='{e.reason}' subscriptions={queries}")
                 self.websocket = None
                 if self.running:
                     await asyncio.sleep(self.reconnect_delay)

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -65,7 +65,7 @@ class AlloraNetworkConfig:
         chain_id="allora-testnet-1",
         url="grpc+https://allora-grpc.testnet.allora.network:443",
         websocket_url="wss://allora-rpc.testnet.allora.network/websocket",
-        faucet_url="https://faucet.testnet.allora.network",
+        faucet_url="https://faucet.testnet.allora.run",
         fee_denom="uallo",
         fee_minimum_gas_price=10.0,
         use_dynamic_gas_price=True,
@@ -149,7 +149,7 @@ class AlloraNetworkConfig:
             fee_denom=require_env((env_prefix or "") + "FEE_DENOM"),
             fee_minimum_gas_price=float(require_env((env_prefix or "") + "FEE_MIN_GAS_PRICE")),
         )
-    
+
     def to_cosmpy_config(self) -> NetworkConfig:
         return NetworkConfig(
             chain_id=self.chain_id,

--- a/src/allora_sdk/worker/context.py
+++ b/src/allora_sdk/worker/context.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from allora_sdk.rpc_client.client import AlloraRPCClient
+
+
+@dataclass
+class RunContext:
+    """Context passed to worker callbacks for a specific topic nonce."""
+
+    client: AlloraRPCClient
+    """RPC client for chain queries needed while computing a callback result."""
+
+    topic_id: int
+    """Allora topic ID the worker is currently processing."""
+
+    nonce: int
+    """Block-height nonce for the submission window being processed."""

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -10,7 +10,7 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     IsWorkerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
-from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult
+from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult, RunContext
 from allora_sdk.worker.utils import resolve_maybe_awaitable
 from allora_sdk.worker.autostake import AutoStakeConfig, AutoStakeRole, process_autostake_rewards_settled, validate_autostake_config
 
@@ -122,7 +122,13 @@ class Forecaster:
             if self.forecast_fn is None:
                 return Exception("no forecast fn configured")
 
-            forecasts_raw = await resolve_maybe_awaitable(self.forecast_fn, nonce)
+            run_context = RunContext(
+                nonce = nonce,
+                client = self.client,
+                topic_id = self.topic_id
+            )
+
+            forecasts_raw = await resolve_maybe_awaitable(self.forecast_fn, run_context)
         except Exception as err:
             logger.error("Forecast function failed", exc_info=True)
             return err
@@ -176,5 +182,3 @@ class Forecaster:
 
 
 _implements: type[UseCase[EventWorkerSubmissionWindowOpened, TForecasterRunFnResult]] = Forecaster
-
-

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -10,7 +10,8 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     IsWorkerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
-from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult, RunContext
+from allora_sdk.worker.context import RunContext
+from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult
 from allora_sdk.worker.utils import resolve_maybe_awaitable
 from allora_sdk.worker.autostake import AutoStakeConfig, AutoStakeRole, process_autostake_rewards_settled, validate_autostake_config
 

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -16,7 +16,8 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     IsWorkerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
-from allora_sdk.worker.types import AlreadySubmittedError, StopQueue, TRunFn, UseCase, WorkerResult, RunContext
+from allora_sdk.worker.context import RunContext
+from allora_sdk.worker.types import AlreadySubmittedError, StopQueue, TRunFn, UseCase, WorkerResult
 from allora_sdk.worker.utils import resolve_maybe_awaitable
 from allora_sdk.worker.autostake import AutoStakeConfig, AutoStakeRole, process_autostake_rewards_settled, validate_autostake_config
 

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -16,7 +16,7 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     IsWorkerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
-from allora_sdk.worker.types import AlreadySubmittedError, StopQueue, TRunFn, UseCase, WorkerResult
+from allora_sdk.worker.types import AlreadySubmittedError, StopQueue, TRunFn, UseCase, WorkerResult, RunContext
 from allora_sdk.worker.utils import resolve_maybe_awaitable
 from allora_sdk.worker.autostake import AutoStakeConfig, AutoStakeRole, process_autostake_rewards_settled, validate_autostake_config
 
@@ -169,7 +169,13 @@ class Inferer:
             if self.predict_fn is None:
                 return Exception("no predict fn configured")
 
-            prediction = await resolve_maybe_awaitable(self.predict_fn, nonce)
+            run_context = RunContext(
+                nonce = nonce,
+                client = self.client,
+                topic_id = self.topic_id
+            )
+
+            prediction = await resolve_maybe_awaitable(self.predict_fn, run_context)
         except Exception as err:
             logger.error("Prediction function failed", exc_info=True)
             return err
@@ -293,4 +299,3 @@ class Inferer:
 
 
 _implements: type[UseCase[EventWorkerSubmissionWindowOpened, TInfererRunFnResult]] = Inferer
-

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -20,14 +20,6 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     IsReputerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
-from allora_sdk.loss_methods.defaults import (
-    LossFn,
-    get_default_loss_fn,
-    is_supported_loss_method,
-    requires_explicit_loss_fn,
-    UnsupportedLossMethodError,
-)
-from allora_sdk.loss_methods.squared_error import squared_error_loss
 from allora_sdk.utils.format import uallo_to_allo
 from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult, RunContext
 from allora_sdk.worker.utils import resolve_maybe_awaitable

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -27,7 +27,9 @@ from allora_sdk.worker.utils import resolve_maybe_awaitable
 logger = logging.getLogger("allora_sdk")
 
 ReputerFnResult = Union[str, float, Decimal]
-ReputerFn = Callable[[RunContext, float], Awaitable[ReputerFnResult]]
+ReputerFnAsync = Callable[[RunContext, float], Awaitable[ReputerFnResult]]
+ReputerFnSync = Callable[[RunContext, float], ReputerFnResult]
+ReputerFn = ReputerFnSync | ReputerFnAsync
 
 class Reputer:
     """

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -124,7 +124,7 @@ class Reputer:
         # GetOpenReputerSubmissionWindows would be the more appropriate RPC call, but
         # it doesn't seem to be implemented in the rpc client
         # Returning [] here means we only react to EventReputerSubmissionWindowOpened
-        return []
+        return set()
 
 
     async def submit(self, nonce: int, account_seq: int) -> WorkerResult[InputValueBundle] | TxError | Exception:

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 import logging
 import math
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Callable, Awaitable
 from cosmpy.aerial.wallet import LocalWallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
@@ -29,14 +29,13 @@ from allora_sdk.loss_methods.defaults import (
 )
 from allora_sdk.loss_methods.squared_error import squared_error_loss
 from allora_sdk.utils.format import uallo_to_allo
-from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult
+from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult, RunContext
 from allora_sdk.worker.utils import resolve_maybe_awaitable
 
 logger = logging.getLogger("allora_sdk")
 
-GroundTruthFnResult = Union[str, float, Decimal]
-GroundTruthFn = TRunFn[GroundTruthFnResult]
-
+ReputerFnResult = Union[str, float, Decimal]
+ReputerFn = Callable[[RunContext, float], Awaitable[ReputerFnResult]]
 
 class Reputer:
     """
@@ -51,8 +50,7 @@ class Reputer:
         wallet: Signing wallet for transactions.
         client: RPC client for chain queries and transaction submission.
         topic_id: Allora topic to repute on.
-        ground_truth_fn: Callback that returns the ground-truth value for a given epoch/nonce.
-        loss_fn: Loss function override. If None, auto-selected from the topic's on-chain loss_method.
+        reputer_fn: Callback that takes an inference value and returns the loss.
         min_stake_uallo: If set, the reputer will top-up self-stake to at least this amount after each submission.
         fee_tier: Transaction fee tier (ECO / STANDARD / PRIORITY).
     """
@@ -62,16 +60,14 @@ class Reputer:
         wallet: LocalWallet,
         client: AlloraRPCClient,
         topic_id: int,
-        ground_truth_fn: GroundTruthFn,
-        loss_fn: Optional[LossFn] = None,
+        reputer_fn: ReputerFn,
         min_stake_uallo: Optional[int] = None,
         fee_tier: FeeTier = FeeTier.STANDARD,
     ):
         self.wallet = wallet
         self.client = client
         self.topic_id = topic_id
-        self.ground_truth_fn = ground_truth_fn
-        self.loss_fn = loss_fn
+        self.reputer_fn = reputer_fn
         self.min_stake_uallo = min_stake_uallo
         self.fee_tier = fee_tier
 
@@ -85,9 +81,6 @@ class Reputer:
 
 
     async def initialize(self) -> bool:
-        # Auto-select loss function for reputers if not explicitly provided
-        await self._maybe_auto_select_loss_fn()
-
         # Check if reputer is already registered
         resp = await self.client.emissions.query.is_reputer_registered_in_topic_id(
             IsReputerRegisteredInTopicIdRequest(
@@ -95,18 +88,23 @@ class Reputer:
                 address=str(self.wallet.address()),
             ),
         )
-        if resp.is_registered:
-            return False
 
-        logger.debug(f"   Registering reputer {str(self.wallet.address())} for topic {self.topic_id}")
-        tx = await self.client.emissions.tx.register(
-            topic_id=self.topic_id,
-            owner_addr=str(self.wallet.address()),
-            sender_addr=str(self.wallet.address()),
-            is_reputer=True,
-            fee_tier=self.fee_tier,
-        )
-        await tx.wait()
+        if not resp.is_registered:
+            logger.debug(f"   Registering reputer {str(self.wallet.address())} for topic {self.topic_id}")
+            tx = await self.client.emissions.tx.register(
+                topic_id=self.topic_id,
+                owner_addr=str(self.wallet.address()),
+                sender_addr=str(self.wallet.address()),
+                is_reputer=True,
+                fee_tier=self.fee_tier,
+            )
+            await tx.wait()
+
+        try:
+            await self._maybe_stake()
+        except Exception as err:
+            logger.error(f"Failed during initial stake fill up: {err}")
+
         return True
 
 
@@ -121,15 +119,12 @@ class Reputer:
 
 
     async def get_unfulfilled_nonces(self) -> set[int]:
-        resp = await self.client.emissions.query.get_unfulfilled_reputer_nonces(
-            GetUnfulfilledReputerNoncesRequest(topic_id=self.topic_id)
-        )
-        nonces = set[int]()
-        if resp.nonces is not None:
-            for nonce_item in resp.nonces.nonces:
-                if nonce_item.reputer_nonce and nonce_item.reputer_nonce.block_height:
-                    nonces.add(nonce_item.reputer_nonce.block_height)
-        return nonces
+
+        # GetUnfulfilledReputerNonces gives all epochs in flight, which is not what we want here
+        # GetOpenReputerSubmissionWindows would be the more appropriate RPC call, but
+        # it doesn't seem to be implemented in the rpc client
+        # Returning [] here means we only react to EventReputerSubmissionWindowOpened
+        return []
 
 
     async def submit(self, nonce: int, account_seq: int) -> WorkerResult[InputValueBundle] | TxError | Exception:
@@ -141,21 +136,6 @@ class Reputer:
         """
 
         sender = str(self.wallet.address())
-
-        # Get ground truth from user callback
-        try:
-            if self.ground_truth_fn is None:
-                return Exception("no ground truth fn configured")
-
-            ground_truth_raw = await resolve_maybe_awaitable(self.ground_truth_fn, nonce)
-            ground_truth = float(ground_truth_raw)
-            if not math.isfinite(ground_truth):
-                raise ValueError(
-                    f"ground_truth must be finite (got non-finite value: {ground_truth})"
-                )
-        except Exception as err:
-            logger.error(f"❌ Ground truth function failed: {err}")
-            return err
 
         # Fetch network inferences at block
         try:
@@ -175,7 +155,7 @@ class Reputer:
 
         # Compute loss bundle
         try:
-            loss_bundle = await self._compute_loss_bundle(ground_truth, value_bundle)
+            loss_bundle = await self._compute_loss_bundle(value_bundle)
         except Exception as err:
             logger.error(f"❌ Failed to compute loss bundle: {err}")
             return err
@@ -226,55 +206,12 @@ class Reputer:
 
         return result
 
-    async def _maybe_auto_select_loss_fn(self) -> None:
-        """
-        Auto-select the reputer loss function based on the topic's on-chain `loss_method`.
-
-        If `self.loss_fn` is already set, this is a no-op.
-        """
-        if self.loss_fn is not None:
-            return
-
-        topic_resp = await self.client.emissions.query.get_topic(
-            GetTopicRequest(topic_id=int(self.topic_id))
-        )
-        topic = topic_resp.topic
-        if topic is None:
-            raise ValueError(f"Topic {self.topic_id} not found on chain")
-
-        loss_method = getattr(topic, "loss_method", "") or ""
-        if not loss_method:
-            logger.info("Topic has no loss_method configured, defaulting to squared error (sqe)")
-            self.loss_fn = squared_error_loss
-            return
-
-        if not is_supported_loss_method(loss_method):
-            raise UnsupportedLossMethodError(
-                loss_method=loss_method,
-                supported=["sqe", "abse", "huber", "logcosh", "bce", "poisson", "ztae", "zptae"],
-            )
-
-        if requires_explicit_loss_fn(loss_method):
-            raise ValueError(
-                f"Topic uses loss_method='{loss_method}' which requires explicit configuration. "
-                "Provide a custom loss_fn using make_ztae_loss() or make_zptae_loss() with "
-                "the appropriate standard deviation for your data: "
-                "e.g. loss_fn=make_ztae_loss(std=0.02) or loss_fn=make_zptae_loss(std=0.02)."
-            )
-
-        self.loss_fn = get_default_loss_fn(loss_method)
-        logger.info(f"Auto-selected loss function for topic loss_method='{loss_method}'")
-
-    async def _compute_loss_bundle(self, ground_truth: float, value_bundle: ValueBundle) -> InputValueBundle:
+    async def _compute_loss_bundle(self, value_bundle: ValueBundle) -> InputValueBundle:
         """
         Compute loss bundle from ground truth and network inferences.
 
         Computes losses for combined, naive, inferer, forecaster, one-out, and one-in values.
         """
-        if not math.isfinite(ground_truth):
-            raise ValueError(
-                f"ground_truth must be finite (got non-finite value: {ground_truth})"
-            )
 
         async def compute_loss(value_str: str) -> str:
             try:
@@ -287,10 +224,17 @@ class Reputer:
                     f"predicted must be finite (got non-finite value: {predicted})"
                 )
 
-            if self.loss_fn is None:
-                raise ValueError("no loss fn configured")
+            if self.reputer_fn is None:
+                raise ValueError("no reputer_fn configured")
 
-            loss = await resolve_maybe_awaitable(self.loss_fn, ground_truth, predicted)
+            nonce = value_bundle.reputer_request_nonce.reputer_nonce.block_height
+            run_context = RunContext(
+                nonce = nonce,
+                client = self.client,
+                topic_id = self.topic_id
+            )
+
+            loss = await resolve_maybe_awaitable(self.reputer_fn, run_context, predicted)
             return str(loss)
 
         # Compute combined and naive losses
@@ -365,7 +309,7 @@ class Reputer:
                     )
                 )
 
-        return InputValueBundle(
+        result = InputValueBundle(
             topic_id=self.topic_id,
             combined_value=combined_loss,
             naive_value=naive_loss,
@@ -377,6 +321,8 @@ class Reputer:
             one_out_inferer_forecaster_values=one_out_inferer_forecaster_values,
         )
 
+        return result
+
 
     async def _maybe_stake(self):
         """
@@ -385,6 +331,7 @@ class Reputer:
         If min_stake_uallo is unset (None) or zero, skip staking.
         Otherwise, top-up only the delta needed to reach min_stake_uallo.
         """
+
         min_stake = self.min_stake_uallo
         if min_stake is None or min_stake == 0:
             return
@@ -407,11 +354,11 @@ class Reputer:
         logger.info(f"   Reputer stake: current={uallo_to_allo(current_stake)} min_stake={uallo_to_allo(min_stake)}")
 
         if current_stake >= min_stake:
-            logger.debug("    Stake above minimum requested stake, skipping adding stake.")
+            logger.debug("   Stake above minimum requested stake, skipping adding stake.")
             return
 
         delta = min_stake - current_stake
-        logger.info(f"Stake below minimum requested stake, adding stake (delta={delta} uallo)")
+        logger.info(f"   Stake below minimum requested stake, adding stake (delta={delta} uallo)")
 
         try:
             pending_tx = await self.client.emissions.tx.add_stake(
@@ -430,5 +377,3 @@ class Reputer:
 
 
 _implements: type[UseCase[EventReputerSubmissionWindowOpened, InputValueBundle]] = Reputer
-
-

--- a/src/allora_sdk/worker/types.py
+++ b/src/allora_sdk/worker/types.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Generic, Protocol, TypeVar, Union, runtime_checkable
 from allora_sdk.rpc_client.protos.cosmos.base.abci.v1beta1 import TxResponse
 from allora_sdk.rpc_client.tx_manager import TxError
-from allora_sdk.rpc_client.client import AlloraRPCClient
+from allora_sdk.worker.context import RunContext
 
 RunFnReturnType = TypeVar("RunFnReturnType")
 ResultDataType = TypeVar("ResultDataType")
@@ -24,12 +24,6 @@ class WorkerNotWhitelistedError(Exception):
 class StopQueue:
     pass
 
-@dataclass
-class RunContext:
-    client: AlloraRPCClient
-    topic_id: int
-    nonce: int
-
 class TSubmissionWindowOpenEventType(Protocol):
     nonce_block_height: int
 
@@ -49,3 +43,8 @@ class UseCase(Protocol[WindowOpenedEvent, UseCaseReturnType]):
 class SupportsAutoStake(Protocol):
     autostake: object | None
     async def handle_rewards_settled(self, event: Any, block_height: int | None = None) -> None: ...
+
+
+@runtime_checkable
+class SupportsInitialStake(Protocol):
+    async def maybe_initial_stake(self) -> None: ...

--- a/src/allora_sdk/worker/types.py
+++ b/src/allora_sdk/worker/types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Generic, Protocol, TypeVar, Union, runtime_checkable
 from allora_sdk.rpc_client.protos.cosmos.base.abci.v1beta1 import TxResponse
 from allora_sdk.rpc_client.tx_manager import TxError
+from allora_sdk.rpc_client.client import AlloraRPCClient
 
 RunFnReturnType = TypeVar("RunFnReturnType")
 ResultDataType = TypeVar("ResultDataType")
@@ -23,13 +24,17 @@ class WorkerNotWhitelistedError(Exception):
 class StopQueue:
     pass
 
+@dataclass
+class RunContext:
+    client: AlloraRPCClient
+    topic_id: int
+    nonce: int
 
 class TSubmissionWindowOpenEventType(Protocol):
     nonce_block_height: int
 
-
 TQueueItem = Union["WorkerResult[RunFnReturnType]", Exception, StopQueue]
-TRunFn = Union[Callable[[int], RunFnReturnType], Callable[[int], Awaitable[RunFnReturnType]]]
+TRunFn = Union[Callable[[RunContext], RunFnReturnType], Callable[[RunContext], Awaitable[RunFnReturnType]]]
 
 class UseCase(Protocol[WindowOpenedEvent, UseCaseReturnType]):
     def name(self) -> str: ...

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -131,7 +131,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
             gt = await gt_fn(context)
             gt_cache = (cache_key, gt)
 
-            logger.debug(f'Ground truth resolved for topic {context.topic_id} at nonce {context.nonce}')
+            logger.info(f'📐 Ground truth for topic {context.topic_id} at nonce {context.nonce}: {gt}')
 
         loss = loss_fn(inference, gt)
 

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -1,13 +1,17 @@
 import inspect
 import logging
 import os
+from datetime import datetime
 from getpass import getpass
 from typing import Any, Awaitable, Callable, ParamSpec, TypeVar, Union, cast
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.mnemonic import PrivateKey, generate_mnemonic
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
-from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetNodeInfoRequest
+from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetNodeInfoRequest, GetBlockByHeightRequest
+from allora_sdk.rpc_client.protos.emissions.v9 import GetNetworkInferencesAtBlockRequest
+from allora_sdk.rpc_client.protos.emissions.v3 import ValueBundle
+from .types import RunContext
 
 logger = logging.getLogger("allora_sdk")
 
@@ -60,3 +64,66 @@ async def resolve_maybe_awaitable(
     return cast(R, out)
 
 
+async def get_block_time(client: AlloraRPCClient, height: int) -> datetime:
+    """Fetch the timestamp of a block at the given height.
+
+    Args:
+        client: The RPC client to query.
+        height: Block height to look up.
+
+    Returns:
+        The block's timestamp as a datetime.
+    """
+    request = GetBlockByHeightRequest(height=height)
+    response = await client.tendermint.query.get_block_by_height(request)
+    block_time = response.sdk_block.header.time
+    return block_time
+
+async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: int) -> ValueBundle:
+    """Fetch the network inference bundle for a topic at a specific block height.
+
+    Args:
+        client: The RPC client to query.
+        topic_id: The topic to retrieve inferences for.
+        nonce: Block height of the last inference (used as the query nonce).
+
+    Returns:
+        The network's inference ValueBundle, which contains all inferer, forecaster, network, etc. values
+    """
+    request = GetNetworkInferencesAtBlockRequest(
+        topic_id=topic_id,
+        block_height_last_inference=nonce,
+    )
+    network_inferences_resp = await client.emissions.query.get_network_inferences_at_block(request)
+    return network_inferences_resp.network_inferences
+
+Truth = TypeVar('Truth')
+def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float]) -> Callable[[RunContext], Awaitable[float]]:
+    """Build a reputer scoring function from separate ground-truth and loss components.
+
+    Returns a function that can be bassed to `AlloraWorker.reputer()`. The ground truth function
+    `gt_fn` is only going to be called once per epoch, then the `loss_fn` gets called once for every
+    value in the `ValueBundle` (passing the fetched ground truth as the second argument).
+
+    Args:
+        gt_fn: Async function that fetches the ground-truth value. The ground truth can be any type.
+        loss_fn: Function that computes a scalar loss given an inference and the ground truth.
+
+    Returns:
+        An async function ``(context, inference) -> float`` suitable for use as a reputer function.
+    """
+    # Ground truth is cached per nonce so it's only fetched once per inference bundle.
+    gt_cache = {}
+
+    async def rep_func(context: RunContext, inference: float) -> float:
+        if context.nonce in gt_cache:
+            gt = gt_cache[context.nonce]
+        else:
+            gt = await gt_fn(context)
+            gt_cache[context.nonce] = gt
+
+        loss = loss_fn(inference, gt)
+
+        return loss
+
+    return rep_func

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -98,7 +98,7 @@ async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: i
     return network_inferences_resp.network_inferences
 
 Truth = TypeVar('Truth')
-def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float]) -> Callable[[RunContext], Awaitable[float]]:
+def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float]) -> Callable[[RunContext, float], Awaitable[float]]:
     """Build a reputer scoring function from separate ground-truth and loss components.
 
     Returns a function that can be bassed to `AlloraWorker.reputer()`. The ground truth function

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import os
+import math
 from datetime import datetime
 from getpass import getpass
 from typing import Any, Awaitable, Callable, ParamSpec, TypeVar, Union, cast
@@ -98,16 +99,21 @@ async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: i
     return network_inferences_resp.network_inferences
 
 Truth = TypeVar('Truth')
-def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float]) -> Callable[[RunContext, float], Awaitable[float]]:
+def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float], log_loss: bool = True) -> Callable[[RunContext, float], Awaitable[float]]:
     """Build a reputer scoring function from separate ground-truth and loss components.
 
     Returns a function that can be bassed to `AlloraWorker.reputer()`. The ground truth function
     `gt_fn` is only going to be called once per epoch, then the `loss_fn` gets called once for every
     value in the `ValueBundle` (passing the fetched ground truth as the second argument).
 
+    The type of the "ground truth" is only used internally, and not exposed by the resulting function.
+    This means it can be arbitrarily chosen and is not defined by the topic. For example, if a loss function
+    requires additional information the "ground truth" type can be a tuple containing this extra information.
+
     Args:
         gt_fn: Async function that fetches the ground-truth value. The ground truth can be any type.
         loss_fn: Function that computes a scalar loss given an inference and the ground truth.
+        log_loss: If true, take log10 of each loss value before submitting (the chain expects log losses)
 
     Returns:
         An async function ``(context, inference) -> float`` suitable for use as a reputer function.
@@ -122,7 +128,12 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
             gt = await gt_fn(context)
             gt_cache[context.nonce] = gt
 
+            logger.info(f'📐 Ground truth for topic {context.topic_id} at nonce {context.nonce}: {gt}')
+
         loss = loss_fn(inference, gt)
+
+        if log_loss:
+            loss = math.log10(loss + 1e-100)
 
         return loss
 

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -4,15 +4,15 @@ import os
 import math
 from datetime import datetime
 from getpass import getpass
-from typing import Any, Awaitable, Callable, ParamSpec, TypeVar, Union, cast
+from typing import Awaitable, Callable, ParamSpec, TypeVar, Union, cast
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.mnemonic import PrivateKey, generate_mnemonic
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
-from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetNodeInfoRequest, GetBlockByHeightRequest
+from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetBlockByHeightRequest
 from allora_sdk.rpc_client.protos.emissions.v9 import GetNetworkInferencesAtBlockRequest
 from allora_sdk.rpc_client.protos.emissions.v3 import ValueBundle
-from .types import RunContext
+from .context import RunContext
 
 logger = logging.getLogger("allora_sdk")
 
@@ -80,7 +80,7 @@ async def get_block_time(client: AlloraRPCClient, height: int) -> datetime:
     block_time = response.sdk_block.header.time
     return block_time
 
-async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: int) -> ValueBundle:
+async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: int) -> ValueBundle | None:
     """Fetch the network inference bundle for a topic at a specific block height.
 
     Args:
@@ -89,7 +89,7 @@ async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: i
         nonce: Block height of the last inference (used as the query nonce).
 
     Returns:
-        The network's inference ValueBundle, which contains all inferer, forecaster, network, etc. values
+        The network's inference ValueBundle, or None if no inferences are available at that height.
     """
     request = GetNetworkInferencesAtBlockRequest(
         topic_id=topic_id,
@@ -102,7 +102,7 @@ Truth = TypeVar('Truth')
 def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float], log_loss: bool = True) -> Callable[[RunContext, float], Awaitable[float]]:
     """Build a reputer scoring function from separate ground-truth and loss components.
 
-    Returns a function that can be bassed to `AlloraWorker.reputer()`. The ground truth function
+    Returns a function that can be passed to `AlloraWorker.reputer()`. The ground truth function
     `gt_fn` is only going to be called once per epoch, then the `loss_fn` gets called once for every
     value in the `ValueBundle` (passing the fetched ground truth as the second argument).
 
@@ -118,17 +118,20 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
     Returns:
         An async function ``(context, inference) -> float`` suitable for use as a reputer function.
     """
-    # Ground truth is cached per nonce so it's only fetched once per inference bundle.
-    gt_cache = {}
+    # Ground truth is cached for the current topic/nonce bundle only.
+    gt_cache: tuple[tuple[int, int], Truth] | None = None
 
     async def rep_func(context: RunContext, inference: float) -> float:
-        if context.nonce in gt_cache:
-            gt = gt_cache[context.nonce]
+        nonlocal gt_cache
+
+        cache_key = (context.topic_id, context.nonce)
+        if gt_cache is not None and gt_cache[0] == cache_key:
+            gt = gt_cache[1]
         else:
             gt = await gt_fn(context)
-            gt_cache[context.nonce] = gt
+            gt_cache = (cache_key, gt)
 
-            logger.info(f'📐 Ground truth for topic {context.topic_id} at nonce {context.nonce}: {gt}')
+            logger.debug(f'Ground truth resolved for topic {context.topic_id} at nonce {context.nonce}')
 
         loss = loss_fn(inference, gt)
 

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -85,6 +85,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         autostake: AutoStakeConfig | None = None,
         sanity_check: SanityCheckConfig | None = None,
         debug: bool = False,
+        show_banner: bool = True,
     ):
         """
         Create an AlloraWorker configured as an inferer.
@@ -129,6 +130,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             max_unfulfilled_nonces=max_unfulfilled_nonces,
             lock=lock,
             debug=debug,
+            show_banner=show_banner,
         )
 
     @classmethod
@@ -145,6 +147,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_REPUTER_NONCES,
         lock: Optional[asyncio.Lock] = None,
         debug: bool = False,
+        show_banner: bool = True,
     ) -> "AlloraWorker[EventReputerSubmissionWindowOpened, InputValueBundle]":
         """
         Create an AlloraWorker configured as a reputer.
@@ -191,6 +194,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             max_unfulfilled_nonces=max_unfulfilled_nonces,
             lock=lock,
             debug=debug,
+            show_banner=show_banner,
         )
 
     @classmethod
@@ -207,6 +211,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         lock: Optional[asyncio.Lock] = None,
         autostake: AutoStakeConfig | None = None,
         debug: bool = False,
+        show_banner: bool = True,
     ) -> "AlloraWorker[EventWorkerSubmissionWindowOpened, TForecasterRunFnResult]":
         """
         Create an AlloraWorker configured as a forecaster.
@@ -251,6 +256,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             max_unfulfilled_nonces=max_unfulfilled_nonces,
             lock=lock,
             debug=debug,
+            show_banner=show_banner,
         )
 
 
@@ -266,6 +272,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
         lock: Optional[asyncio.Lock] = None,
         debug: bool = False,
+        show_banner: bool = True,
     ) -> None:
         """
         Initialize the Allora worker.
@@ -296,6 +303,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         self.fee_tier = fee_tier
         self.polling_interval = polling_interval
         self.max_unfulfilled_nonces = max(1, max_unfulfilled_nonces)
+        self.show_banner = show_banner
 
         self.submitted_nonces = TimestampOrderedSet()
         self._submit_lock = lock if lock is not None else asyncio.Lock()
@@ -322,20 +330,23 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _show_banner(self):
         resp = await self.client.emissions.query.get_topic(GetTopicRequest(topic_id=int(self.topic_id)))
 
-        print(indent(dedent(
-            rf"""
-                 _    _     _     ___  ____      _
-                / \  | |   | |   / _ \|  _ \    / \
-               / _ \ | |   | |  | | | | |_) |  / _ \
-              / ___ \| |___| |__| |_| |  _ <  / ___ \        Chain:   {self._chain_id}
-             /_/   \_\_____|_____\___/|_| \_\/_/   \_\       Topic:   {resp.topic.metadata if resp.topic else '-'} (ID: {self.topic_id})
-             __        _____  ____  _  _______ ____          Address: {self.address}
-             \ \      / / _ \|  _ \| |/ / ____|  _ \         Role:    {self.use_case.name().upper()}
-              \ \ /\ / / | | | |_) | ' /|  _| | |_) |
-               \ V  V /| |_| |  _ <| . \| |___|  _ <
-                \_/\_/  \___/|_| \_\_|\_\_____|_| \_\
-            """
-        ), "   "))
+        if self.show_banner:
+            print(indent(dedent(
+                rf"""
+                     _    _     _     ___  ____      _
+                    / \  | |   | |   / _ \|  _ \    / \
+                   / _ \ | |   | |  | | | | |_) |  / _ \
+                  / ___ \| |___| |__| |_| |  _ <  / ___ \        Chain:   {self._chain_id}
+                 /_/   \_\_____|_____\___/|_| \_\/_/   \_\       Topic:   {resp.topic.metadata if resp.topic else '-'} (ID: {self.topic_id})
+                 __        _____  ____  _  _______ ____          Address: {self.address}
+                 \ \      / / _ \|  _ \| |/ / ____|  _ \         Role:    {self.use_case.name().upper()}
+                  \ \ /\ / / | | | |_) | ' /|  _| | |_) |
+                   \ V  V /| |_| |  _ <| . \| |___|  _ <
+                    \_/\_/  \___/|_| \_\_|\_\_____|_| \_\
+                """
+            ), "   "))
+        else:
+            print(f"Allora Worker - Chain: {self._chain_id}, Topic: {resp.topic.metadata if resp.topic else '-'} (ID: {self.topic_id}), Address: {self.address}, Role: {self.use_case.name().upper()}")
 
 
     async def _log_balance(self):
@@ -489,7 +500,9 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         logger.debug(f"Starting Allora {self.use_case.name()} for topic {self.topic_id}")
 
         try:
-            did_register = await self.use_case.initialize()
+            # use_case.initialize() may send txs, so guard it with _submit_lock to avoid account sequence issues
+            async with self._submit_lock:
+                did_register = await self.use_case.initialize()
             if did_register:
                 logger.info(f"✅ Registered {self.use_case.name()} {self.address} for topic {self.topic_id}")
 

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -36,7 +36,7 @@ from allora_sdk.utils import Context, TimestampOrderedSet, format_allo_from_uall
 from allora_sdk.logging_config import setup_sdk_logging
 from allora_sdk.worker.forecaster import Forecaster, TForecasterRunFn, TForecasterRunFnResult
 from allora_sdk.worker.inferer import Inferer, SanityCheckConfig, TInfererRunFn, TInfererRunFnResult
-from allora_sdk.worker.reputer import GroundTruthFn, LossFn, Reputer
+from allora_sdk.worker.reputer import Reputer, ReputerFn
 from allora_sdk.worker.autostake import AutoStakeConfig
 from allora_sdk.worker.types import (
     AlreadySubmittedError,
@@ -81,6 +81,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
+        lock: Optional[asyncio.Lock] = None,
         autostake: AutoStakeConfig | None = None,
         sanity_check: SanityCheckConfig | None = None,
         debug: bool = False,
@@ -126,14 +127,14 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier=fee_tier,
             polling_interval=polling_interval,
             max_unfulfilled_nonces=max_unfulfilled_nonces,
+            lock=lock,
             debug=debug,
         )
 
     @classmethod
     def reputer(
         cls,
-        ground_truth_fn: GroundTruthFn,
-        loss_fn: Optional[LossFn] = None,
+        reputer_fn: ReputerFn,
         wallet: Optional[AlloraWalletConfig] = None,
         network: AlloraNetworkConfig = AlloraNetworkConfig.testnet(),
         api_key: Optional[str] = None,
@@ -142,16 +143,14 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         polling_interval: int = 120,
         min_stake_uallo: Optional[int] = None,
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_REPUTER_NONCES,
+        lock: Optional[asyncio.Lock] = None,
         debug: bool = False,
     ) -> "AlloraWorker[EventReputerSubmissionWindowOpened, InputValueBundle]":
         """
         Create an AlloraWorker configured as a reputer.
 
         Args:
-            ground_truth_fn: Function that returns ground truth values (str or float)
-            loss_fn: Loss function to calculate error between ground truth and predictions.
-                     If None (default), the SDK will automatically select the appropriate
-                     loss function based on the topic's on-chain `loss_method` configuration.
+            reputer_fn: Function that takes an inference value and returns a loss
             wallet: Wallet configuration (private key, mnemonic, or file)
             network: Allora network configuration (testnet/mainnet/custom)
             api_key: API key for testnet faucet (if needed)
@@ -176,8 +175,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         )
         return AlloraWorker[EventReputerSubmissionWindowOpened, InputValueBundle](
             use_case=Reputer(
-                ground_truth_fn=ground_truth_fn,
-                loss_fn=loss_fn,
+                reputer_fn=reputer_fn,
                 fee_tier=fee_tier,
                 topic_id=topic_id,
                 client=client,
@@ -191,6 +189,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier=fee_tier,
             polling_interval=polling_interval,
             max_unfulfilled_nonces=max_unfulfilled_nonces,
+            lock=lock,
             debug=debug,
         )
 
@@ -205,6 +204,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
+        lock: Optional[asyncio.Lock] = None,
         autostake: AutoStakeConfig | None = None,
         debug: bool = False,
     ) -> "AlloraWorker[EventWorkerSubmissionWindowOpened, TForecasterRunFnResult]":
@@ -249,6 +249,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier=fee_tier,
             polling_interval=polling_interval,
             max_unfulfilled_nonces=max_unfulfilled_nonces,
+            lock=lock,
             debug=debug,
         )
 
@@ -263,6 +264,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         fee_tier: FeeTier = FeeTier.STANDARD,
         polling_interval: int = 120,
         max_unfulfilled_nonces: int = DEFAULT_MAX_UNFULFILLED_WORKER_NONCES,
+        lock: Optional[asyncio.Lock] = None,
         debug: bool = False,
     ) -> None:
         """
@@ -277,6 +279,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
             max_unfulfilled_nonces: Maximum number of nonces to process per cycle
+            lock: if multiple AlloraWorkers are using the same address, pass the same asyncio.Lock to all of them to avoid account sequence issues
             debug: Enable debug logging
         """
         if use_case is None:
@@ -295,7 +298,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         self.max_unfulfilled_nonces = max(1, max_unfulfilled_nonces)
 
         self.submitted_nonces = TimestampOrderedSet()
-        self._submit_lock = asyncio.Lock()
+        self._submit_lock = lock if lock is not None else asyncio.Lock()
 
         setup_sdk_logging(debug=debug)
 
@@ -380,7 +383,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
                         "address": self.address,
                     },
                     headers={
-                        "x-api-key": self.api_key,
+                        "x-api-key": self.api_key or "None",
                     },
                 )
                 faucet_resp.raise_for_status()
@@ -419,6 +422,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             return "colab"
         else:
             return "shell"
+
 
     def _setup_signal_handlers(self, ctx: Context):
         env = self._detect_environment()
@@ -505,6 +509,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             ctx.cancel()
         finally:
             await self._cleanup(ctx)
+
 
     async def _run_with_context(self, ctx: Context) -> AsyncIterator[WorkerResult | Exception]:
         await self._ensure_initialized()
@@ -761,5 +766,3 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         if self._ctx:
             logger.debug("Manually stopping worker")
             self._ctx.cancel()
-
-

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -100,7 +100,9 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             polling_interval: Interval in seconds to poll for new submission windows
             autostake: Optional autostake config to stake this worker's rewards to a reputer or validator
             sanity_check: Optional sanity check config; defaults to enabled with 60s throttle interval
+            lock: asyncio.Lock to share with other AlloraWorker instances using the same wallet
             debug: Enable debug logging
+            show_banner: Set to false to replace startup banner by one-line message
 
         Returns:
             An instance of AlloraWorker configured as an inferer
@@ -161,7 +163,9 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
             min_stake_uallo: Minimum stake in uallo to top-up to (used for dynamic staking)
+            lock: asyncio.Lock to share with other AlloraWorker instances using the same wallet
             debug: Enable debug logging
+            show_banner: Set to false to replace startup banner by one-line message
 
         Returns:
             An instance of AlloraWorker configured as a reputer
@@ -227,7 +231,9 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
             autostake: Optional autostake config to stake this worker's rewards to a reputer or validator
+            lock: asyncio.Lock to share with other AlloraWorker instances using the same wallet
             debug: Enable debug logging
+            show_banner: Set to false to replace startup banner by one-line message
 
         Returns:
             An instance of AlloraWorker configured as a forecaster

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -98,6 +98,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             topic_id: The Allora network topic ID to submit predictions to
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
+            max_unfulfilled_nonces: if more than this many open nonces, skip the oldest ones
             autostake: Optional autostake config to stake this worker's rewards to a reputer or validator
             sanity_check: Optional sanity check config; defaults to enabled with 60s throttle interval
             lock: asyncio.Lock to share with other AlloraWorker instances using the same wallet
@@ -163,6 +164,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
             min_stake_uallo: Minimum stake in uallo to top-up to (used for dynamic staking)
+            max_unfulfilled_nonces: if more than this many open nonces, skip the oldest ones
             lock: asyncio.Lock to share with other AlloraWorker instances using the same wallet
             debug: Enable debug logging
             show_banner: Set to false to replace startup banner by one-line message
@@ -230,8 +232,9 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             topic_id: The Allora network topic ID to submit forecasts to
             fee_tier: Transaction fee tier (ECO/STANDARD/PRIORITY)
             polling_interval: Interval in seconds to poll for new submission windows
-            autostake: Optional autostake config to stake this worker's rewards to a reputer or validator
+            max_unfulfilled_nonces: if more than this many open nonces, skip the oldest ones
             lock: asyncio.Lock to share with other AlloraWorker instances using the same wallet
+            autostake: Optional autostake config to stake this worker's rewards to a reputer or validator
             debug: Enable debug logging
             show_banner: Set to false to replace startup banner by one-line message
 
@@ -735,7 +738,6 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
                     result is not None
                 ):
                     await self._queue.put(result)
-
 
         new_nonces = sorted(list(new_nonces))
         if len(new_nonces) > self.max_unfulfilled_nonces:

--- a/tests/test_reputer_loss_safety.py
+++ b/tests/test_reputer_loss_safety.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
 from allora_sdk.loss_methods.defaults import requires_explicit_loss_fn
 from allora_sdk.loss_methods.squared_error import squared_error_loss
-from allora_sdk.loss_methods.ztae import make_ztae_loss
-from allora_sdk.loss_methods.zptae import make_zptae_loss
 from allora_sdk.worker.reputer import Reputer
 
 
@@ -36,46 +34,26 @@ def reputer_with_sqe():
     wallet = Mock()
     wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
     client = Mock()
+
+    async def reputer_fn(_ctx, prediction: float) -> float:
+        return squared_error_loss(10.0, prediction)
+
     return Reputer(
         wallet=wallet,
         client=client,
         topic_id=1,
-        ground_truth_fn=lambda _: 10.0,
-        loss_fn=squared_error_loss,
+        reputer_fn=reputer_fn,
     )
 
 
 class TestComputeLossBundleNonFinite:
-    """Test that _compute_loss_bundle rejects non-finite ground_truth and predicted values."""
-
-    @pytest.mark.asyncio
-    async def test_ground_truth_nan_raises(self, reputer_with_sqe):
-        vb = _make_value_bundle(combined_value="5.0", naive_value="5.0")
-        with pytest.raises(ValueError) as exc_info:
-            await reputer_with_sqe._compute_loss_bundle(float("nan"), vb)
-        assert "ground_truth" in str(exc_info.value)
-        assert "finite" in str(exc_info.value).lower()
-
-    @pytest.mark.asyncio
-    async def test_ground_truth_inf_raises(self, reputer_with_sqe):
-        vb = _make_value_bundle(combined_value="5.0", naive_value="5.0")
-        with pytest.raises(ValueError) as exc_info:
-            await reputer_with_sqe._compute_loss_bundle(float("inf"), vb)
-        assert "ground_truth" in str(exc_info.value)
-        assert "finite" in str(exc_info.value).lower()
-
-    @pytest.mark.asyncio
-    async def test_ground_truth_neg_inf_raises(self, reputer_with_sqe):
-        vb = _make_value_bundle(combined_value="5.0", naive_value="5.0")
-        with pytest.raises(ValueError) as exc_info:
-            await reputer_with_sqe._compute_loss_bundle(float("-inf"), vb)
-        assert "ground_truth" in str(exc_info.value)
+    """Test that _compute_loss_bundle rejects non-finite predicted values."""
 
     @pytest.mark.asyncio
     async def test_predicted_nan_in_combined_raises(self, reputer_with_sqe):
         vb = _make_value_bundle(combined_value="nan", naive_value="0")
         with pytest.raises(ValueError) as exc_info:
-            await reputer_with_sqe._compute_loss_bundle(10.0, vb)
+            await reputer_with_sqe._compute_loss_bundle(vb)
         assert "predicted" in str(exc_info.value)
         assert "finite" in str(exc_info.value).lower()
 
@@ -83,13 +61,13 @@ class TestComputeLossBundleNonFinite:
     async def test_predicted_inf_in_combined_raises(self, reputer_with_sqe):
         vb = _make_value_bundle(combined_value="inf", naive_value="0")
         with pytest.raises(ValueError) as exc_info:
-            await reputer_with_sqe._compute_loss_bundle(10.0, vb)
+            await reputer_with_sqe._compute_loss_bundle(vb)
         assert "predicted" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_finite_values_succeed(self, reputer_with_sqe):
         vb = _make_value_bundle(combined_value="8.0", naive_value="9.0")
-        result = await reputer_with_sqe._compute_loss_bundle(10.0, vb)
+        result = await reputer_with_sqe._compute_loss_bundle(vb)
         assert result.combined_value == "4.0"  # (10-8)^2 = 4
         assert result.naive_value == "1.0"  # (10-9)^2 = 1
 
@@ -110,68 +88,3 @@ class TestRequiresExplicitLossFn:
     def test_other_methods_no_requirement(self, method: str):
         assert requires_explicit_loss_fn(method) is False
 
-
-class TestMaybeAutoSelectLossFnZtaeZptae:
-    """Test that _maybe_auto_select_loss_fn raises when topic uses ztae/zptae without explicit loss_fn."""
-
-    @pytest.fixture
-    def reputer_no_loss_fn(self):
-        wallet = Mock()
-        wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
-        client = Mock()
-        return Reputer(
-            wallet=wallet,
-            client=client,
-            topic_id=1,
-            ground_truth_fn=lambda _: 10.0,
-            loss_fn=None,
-        )
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("loss_method", ["ztae", "zptae", "ZTAE", "ztae_loss"])
-    async def test_ztae_zptae_without_loss_fn_raises(
-        self, reputer_no_loss_fn: Reputer, loss_method: str
-    ):
-        topic = Mock()
-        topic.loss_method = loss_method
-        reputer_no_loss_fn.client.emissions.query.get_topic = AsyncMock(
-            return_value=Mock(topic=topic)
-        )
-
-        with pytest.raises(ValueError) as exc_info:
-            await reputer_no_loss_fn._maybe_auto_select_loss_fn()
-
-        msg = str(exc_info.value)
-        assert "make_ztae_loss" in msg or "make_zptae_loss" in msg
-        assert "explicit" in msg.lower()
-        assert loss_method.lower() in msg.lower() or "ztae" in msg or "zptae" in msg
-
-    @pytest.mark.asyncio
-    async def test_ztae_with_explicit_loss_fn_succeeds(self):
-        wallet = Mock()
-        wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
-        client = Mock()
-        reputer = Reputer(
-            wallet=wallet,
-            client=client,
-            topic_id=1,
-            ground_truth_fn=lambda _: 10.0,
-            loss_fn=make_ztae_loss(std=0.02),
-        )
-        await reputer._maybe_auto_select_loss_fn()
-        assert reputer.loss_fn is not None
-
-    @pytest.mark.asyncio
-    async def test_zptae_with_explicit_loss_fn_succeeds(self):
-        wallet = Mock()
-        wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
-        client = Mock()
-        reputer = Reputer(
-            wallet=wallet,
-            client=client,
-            topic_id=1,
-            ground_truth_fn=lambda _: 10.0,
-            loss_fn=make_zptae_loss(std=0.02),
-        )
-        await reputer._maybe_auto_select_loss_fn()
-        assert reputer.loss_fn is not None

--- a/tests/test_reputer_submit.py
+++ b/tests/test_reputer_submit.py
@@ -36,6 +36,20 @@ def _make_value_bundle() -> Mock:
     return bundle
 
 
+def _make_reputer(client: Mock, reputer_fn=None) -> Reputer:
+    async def default_reputer_fn(_ctx, _prediction: float) -> float:
+        return 1.0
+
+    return Reputer(
+        wallet=_make_wallet(),
+        client=client,
+        topic_id=9,
+        reputer_fn=reputer_fn or default_reputer_fn,
+        min_stake_uallo=None,
+        fee_tier=FeeTier.STANDARD,
+    )
+
+
 @pytest.mark.asyncio
 async def test_submit_returns_already_submitted_error_from_code() -> None:
     client = _make_client()
@@ -46,15 +60,7 @@ async def test_submit_returns_already_submitted_error_from_code() -> None:
         side_effect=TxError(codespace="emissions", code=68, message="duplicate", tx_hash="tx1")
     )
 
-    reputer = Reputer(
-        wallet=_make_wallet(),
-        client=client,
-        topic_id=9,
-        ground_truth_fn=lambda _: 10.0,
-        loss_fn=lambda gt, pred: abs(gt - pred),
-        min_stake_uallo=None,
-        fee_tier=FeeTier.STANDARD,
-    )
+    reputer = _make_reputer(client)
     reputer._maybe_stake = AsyncMock(return_value=None)
 
     result = await reputer.submit(nonce=123, account_seq=4)
@@ -71,15 +77,7 @@ async def test_submit_returns_error_when_network_inferences_missing() -> None:
     )
     client.emissions.tx.insert_reputer_payload = AsyncMock()
 
-    reputer = Reputer(
-        wallet=_make_wallet(),
-        client=client,
-        topic_id=9,
-        ground_truth_fn=lambda _: 10.0,
-        loss_fn=lambda gt, pred: abs(gt - pred),
-        min_stake_uallo=None,
-        fee_tier=FeeTier.STANDARD,
-    )
+    reputer = _make_reputer(client)
     reputer._maybe_stake = AsyncMock(return_value=None)
 
     result = await reputer.submit(nonce=123, account_seq=4)
@@ -87,3 +85,22 @@ async def test_submit_returns_error_when_network_inferences_missing() -> None:
     assert isinstance(result, Exception)
     assert "no network inferences found" in str(result).lower()
     client.emissions.tx.insert_reputer_payload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_unfulfilled_nonces_uses_reputer_request_nonces() -> None:
+    client = _make_client()
+    client.emissions.query.get_unfulfilled_reputer_nonces = AsyncMock(
+        return_value=Mock(
+            nonces=Mock(
+                nonces=[
+                    Mock(reputer_nonce=Mock(block_height=101)),
+                    Mock(reputer_nonce=Mock(block_height=202)),
+                ]
+            )
+        )
+    )
+
+    reputer = _make_reputer(client)
+
+    assert await reputer.get_unfulfilled_nonces() == set()

--- a/tests/test_sequence_safety.py
+++ b/tests/test_sequence_safety.py
@@ -192,14 +192,16 @@ class TestReputerSequenceSafePath:
             )
         )
 
+        async def reputer_fn(_ctx, _prediction: float) -> float:
+            return 0.0
+
         reputer = Reputer(
             wallet=mock_wallet,
             client=mock_client,
             topic_id=69,
-            ground_truth_fn=lambda n: 1.0,
+            reputer_fn=reputer_fn,
             min_stake_uallo=100,
         )
-        reputer.loss_fn = lambda g, p: 0.0
 
         with patch.object(Reputer, "_maybe_stake", mock_maybe_stake):
             result = await reputer.submit(nonce=100, account_seq=0)
@@ -246,14 +248,16 @@ class TestReputerSequenceSafePath:
             )
         )
 
+        async def reputer_fn(_ctx, _prediction: float) -> float:
+            return 0.0
+
         reputer = Reputer(
             wallet=mock_wallet,
             client=mock_client,
             topic_id=69,
-            ground_truth_fn=lambda n: 1.0,
+            reputer_fn=reputer_fn,
             min_stake_uallo=100,
         )
-        reputer.loss_fn = lambda g, p: 0.0
 
         with patch.object(Reputer, "_maybe_stake", mock_maybe_stake):
             result = await reputer.submit(nonce=100, account_seq=0)
@@ -308,14 +312,16 @@ class TestReputerSequenceSafePath:
             )
         )
 
+        async def reputer_fn(_ctx, _prediction: float) -> float:
+            return 0.0
+
         reputer = Reputer(
             wallet=mock_wallet,
             client=mock_client,
             topic_id=69,
-            ground_truth_fn=lambda n: 1.0,
+            reputer_fn=reputer_fn,
             min_stake_uallo=100,
         )
-        reputer.loss_fn = lambda g, p: 0.0
 
         with patch.object(Reputer, "_maybe_stake", mock_maybe_stake_raise):
             result = await reputer.submit(nonce=100, account_seq=0)

--- a/tests/test_worker_review_fixes.py
+++ b/tests/test_worker_review_fixes.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from allora_sdk.rpc_client.tx_manager import FeeTier
-from allora_sdk.utils import Context
 from allora_sdk.worker.context import RunContext
-from allora_sdk.worker.reputer import Reputer
 from allora_sdk.worker.utils import make_reputer_function
 from allora_sdk.worker.worker import AlloraWorker
 
@@ -69,26 +65,7 @@ async def test_faucet_request_omits_api_key_header_when_unset() -> None:
     ):
         await worker._maybe_faucet_request()
 
-    assert post.call_args.kwargs["headers"] is None
-
-
-@pytest.mark.asyncio
-async def test_show_banner_false_prints_nothing() -> None:
-    client = _make_worker_client()
-    worker = AlloraWorker(
-        use_case=_make_use_case(),
-        client=client,
-        address="allo1worker",
-        topic_id=69,
-        show_banner=False,
-    )
-    worker._initialized = True
-    worker._chain_id = "allora-testnet-1"
-
-    with patch("builtins.print") as print_mock:
-        await worker._show_banner()
-
-    print_mock.assert_not_called()
+    assert post.call_args.kwargs["headers"] == {"x-api-key": "None"}
 
 
 @pytest.mark.asyncio
@@ -110,50 +87,3 @@ async def test_make_reputer_function_uses_single_entry_topic_nonce_cache() -> No
     assert calls == [(1, 10), (2, 10), (1, 10)]
 
 
-@pytest.mark.asyncio
-async def test_reputer_initial_stake_runs_after_initialize_lock_released() -> None:
-    call_order: list[str] = []
-    lock = asyncio.Lock()
-    client = _make_worker_client()
-    client.network.faucet_url = None
-    wallet = Mock()
-    wallet.address.return_value = "allo1reputer"
-
-    async def reputer_fn(_ctx: RunContext, _prediction: float) -> float:
-        return 0.0
-
-    reputer = Reputer(
-        wallet=wallet,
-        client=client,
-        topic_id=69,
-        reputer_fn=reputer_fn,
-        min_stake_uallo=100,
-        fee_tier=FeeTier.STANDARD,
-    )
-
-    async def initialize() -> bool:
-        call_order.append("initialize")
-        assert lock.locked()
-        return False
-
-    async def maybe_initial_stake() -> None:
-        call_order.append("initial_stake")
-        assert not lock.locked()
-
-    reputer.initialize = initialize  # type: ignore[method-assign]
-    reputer.maybe_initial_stake = maybe_initial_stake  # type: ignore[method-assign]
-
-    worker = AlloraWorker(
-        use_case=reputer,
-        client=client,
-        address="allo1reputer",
-        topic_id=69,
-        polling_interval=999,
-        lock=lock,
-        show_banner=False,
-    )
-
-    async for _ in worker.run(timeout=0.01):
-        pass
-
-    assert call_order == ["initialize", "initial_stake"]

--- a/tests/test_worker_review_fixes.py
+++ b/tests/test_worker_review_fixes.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from allora_sdk.rpc_client.tx_manager import FeeTier
+from allora_sdk.utils import Context
+from allora_sdk.worker.context import RunContext
+from allora_sdk.worker.reputer import Reputer
+from allora_sdk.worker.utils import make_reputer_function
+from allora_sdk.worker.worker import AlloraWorker
+
+
+def _make_worker_client() -> Mock:
+    client = Mock()
+    client.raise_for_chain_id_mismatch = AsyncMock(return_value="allora-testnet-1")
+    client.emissions = Mock()
+    client.emissions.query = Mock()
+    client.emissions.query.get_topic = AsyncMock(return_value=Mock(topic=Mock(metadata="test")))
+    client.bank = Mock()
+    client.bank.query = Mock()
+    client.bank.query.balance = AsyncMock(return_value=Mock(balance=Mock(amount="0")))
+    client.auth = Mock()
+    client.auth.query = Mock()
+    client.auth.query.account_info = AsyncMock(return_value=Mock(info=Mock(sequence=0)))
+    client.network = Mock(faucet_url="https://faucet.example")
+    client.events = Mock()
+    client.events.subscribe_new_block_events_typed = AsyncMock(return_value="sub-id")
+    client.events.unsubscribe = AsyncMock()
+    return client
+
+
+def _make_use_case() -> Mock:
+    use_case = Mock()
+    use_case.name.return_value = "inferer"
+    use_case.initialize = AsyncMock(return_value=False)
+    use_case.worker_is_whitelisted = AsyncMock(return_value=True)
+    use_case.get_unfulfilled_nonces = AsyncMock(return_value=set())
+    use_case.submit = AsyncMock()
+    return use_case
+
+
+@pytest.mark.asyncio
+async def test_faucet_request_omits_api_key_header_when_unset() -> None:
+    client = _make_worker_client()
+    worker = AlloraWorker(
+        use_case=_make_use_case(),
+        client=client,
+        address="allo1worker",
+        api_key=None,
+        topic_id=69,
+        show_banner=False,
+    )
+    worker._initialized = True
+    worker._chain_id = "allora-testnet-1"
+    client.bank.query.balance.side_effect = [
+        Mock(balance=Mock(amount="0")),
+        Mock(balance=Mock(amount="100000000")),
+    ]
+
+    faucet_resp = Mock()
+    faucet_resp.raise_for_status = Mock()
+
+    with (
+        patch("allora_sdk.worker.worker.requests.post", return_value=faucet_resp) as post,
+        patch("allora_sdk.worker.worker.asyncio.sleep", new=AsyncMock()),
+    ):
+        await worker._maybe_faucet_request()
+
+    assert post.call_args.kwargs["headers"] is None
+
+
+@pytest.mark.asyncio
+async def test_show_banner_false_prints_nothing() -> None:
+    client = _make_worker_client()
+    worker = AlloraWorker(
+        use_case=_make_use_case(),
+        client=client,
+        address="allo1worker",
+        topic_id=69,
+        show_banner=False,
+    )
+    worker._initialized = True
+    worker._chain_id = "allora-testnet-1"
+
+    with patch("builtins.print") as print_mock:
+        await worker._show_banner()
+
+    print_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_make_reputer_function_uses_single_entry_topic_nonce_cache() -> None:
+    calls: list[tuple[int, int]] = []
+
+    async def gt_fn(ctx: RunContext) -> float:
+        calls.append((ctx.topic_id, ctx.nonce))
+        return float(len(calls))
+
+    rep_fn = make_reputer_function(gt_fn, lambda prediction, truth: prediction + truth, log_loss=False)
+    client = Mock()
+
+    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 1.0)
+    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 2.0)
+    await rep_fn(RunContext(client=client, topic_id=2, nonce=10), 3.0)
+    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 4.0)
+
+    assert calls == [(1, 10), (2, 10), (1, 10)]
+
+
+@pytest.mark.asyncio
+async def test_reputer_initial_stake_runs_after_initialize_lock_released() -> None:
+    call_order: list[str] = []
+    lock = asyncio.Lock()
+    client = _make_worker_client()
+    client.network.faucet_url = None
+    wallet = Mock()
+    wallet.address.return_value = "allo1reputer"
+
+    async def reputer_fn(_ctx: RunContext, _prediction: float) -> float:
+        return 0.0
+
+    reputer = Reputer(
+        wallet=wallet,
+        client=client,
+        topic_id=69,
+        reputer_fn=reputer_fn,
+        min_stake_uallo=100,
+        fee_tier=FeeTier.STANDARD,
+    )
+
+    async def initialize() -> bool:
+        call_order.append("initialize")
+        assert lock.locked()
+        return False
+
+    async def maybe_initial_stake() -> None:
+        call_order.append("initial_stake")
+        assert not lock.locked()
+
+    reputer.initialize = initialize  # type: ignore[method-assign]
+    reputer.maybe_initial_stake = maybe_initial_stake  # type: ignore[method-assign]
+
+    worker = AlloraWorker(
+        use_case=reputer,
+        client=client,
+        address="allo1reputer",
+        topic_id=69,
+        polling_interval=999,
+        lock=lock,
+        show_banner=False,
+    )
+
+    async for _ in worker.run(timeout=0.01):
+        pass
+
+    assert call_order == ["initialize", "initial_stake"]


### PR DESCRIPTION
* revise examples
* use context instead of `nonce` for all callbacks
* change from `loss_fn` and `ground_truth_fn` to `reputer_fn`
* fix some logging so that user logs actually get displayed
* new faucet URL + correct handling of "None" api key
* run `_maybe_stake()` at initialization, and even if submission failed
* don't use `GetUnfulfilledReputerNonces` for reputers (it gives all nonces in flight)
* convenience functions `get_block_time`, `get_network_inference`, `make_reputer_function`
* allow lock sharing between workers

additional changes on 2026-05-07 and 2026-05-12:
* added a flag to turn the banner off
* included worker registration into the submit lock to avoid account sequence errors at registration
* set timeout waiting for reply on websocket (suggested by Claude)
* more logging on websocket disconnect
* automatically take log of loss


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches worker callbacks to a context-based API and replaces ground-truth/loss callbacks with a single `reputer_fn`. Adds small utilities and reliability/logging fixes across staking, registration, WebSockets, and examples/README.

- **New Features**
  - Context API: all callbacks now receive `RunContext`; exports `RunContext`, `ValueBundle`, `get_block_time`, `get_network_inference`, `make_reputer_function`; examples updated.
  - Reputer: single `reputer_fn(context, inference) -> loss`; `make_reputer_function(get_ground_truth, loss_fn, log_loss=True)` caches per topic+nonce, logs ground truth, applies log10 by default; uses the request nonce; reacts only to window-open events; tops up stake at init.
  - Reliability/logging: shared `asyncio.Lock` guards registration and submissions; optional `show_banner`; user logs no longer suppressed; faucet header sends `"None"` when API key is unset and testnet faucet URL updated; WebSocket now has a 30s read timeout with auto-ping and close logs include code/reason/subscriptions.

- **Migration**
  - Update `inferer`/`forecaster` run signatures to accept `RunContext`.
  - Replace `ground_truth_fn`/`loss_fn` with a single `reputer_fn`. Use `make_reputer_function(get_ground_truth, loss_fn, log_loss=...)` if needed.
  - If multiple workers share a wallet, pass a shared `asyncio.Lock` via `lock=`.

<sup>Written for commit 7f42bf3f003fe9fe92e47067baf7ffc037b01659. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/61?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->







