### PR TITLE
fix: grpclib error handling — wrong exception type + no transport recovery (DEVOP-595)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "websockets >= 15.0.1",
     "grpclib >= 0.4.8",
     "betterproto2 ~= 0.7.0",
-    "requests *",
     "async-timeout>=5.0.1",
     "hdwallets>=0.1.2",
     "mnemonic>=0.21",

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -74,7 +74,27 @@ class AlloraRPCClient:
         self.ledger_client = LedgerClient(cfg=self.network.to_cosmpy_config())
         self._initialize_wallet(wallet)
 
-        parsed_url = parse_url(self.network.url)
+        self._parsed_url = parse_url(self.network.url)
+        self.grpc_client: Optional[Channel] = None
+
+        self._build_clients()
+
+        if self.network.websocket_url is not None:
+            self.events = AlloraWebsocketSubscriber(self.network.websocket_url)
+
+        logger.debug(f"Initialized Allora client for {self.network.chain_id}")
+
+
+    def _build_clients(self):
+        """
+        (Re)build the gRPC / REST query stubs and the TxManager.
+
+        Called once from __init__ and again from _reconnect_grpc() when a
+        transport-layer failure forces us to dial a new channel. Splitting
+        this out keeps the construction logic in one place so the
+        reconnect path can't drift from the initial-setup path.
+        """
+        parsed_url = self._parsed_url
 
         if parsed_url.protocol == Protocol.GRPC:
             self.grpc_client = Channel(host=parsed_url.hostname, port=parsed_url.port, ssl=parsed_url.secure)
@@ -97,7 +117,15 @@ class AlloraRPCClient:
             mint_query: rest.MintV5QueryServiceLike = rest.MintV5RestQueryServiceClient(parsed_url.rest_url)
             feemarket_query: rest.FeemarketFeemarketV1QueryLike = rest.FeemarketFeemarketV1RestQueryClient(parsed_url.rest_url)
 
-        if self.wallet is not None:
+        # If we already have a tx_manager (reconnect path), re-bind its
+        # stub references in-place so the existing instance stays valid
+        # for any caller that captured it. Otherwise construct fresh.
+        if self.tx_manager is not None:
+            self.tx_manager.tx_client = tx_query
+            self.tx_manager.auth_client = auth_query
+            self.tx_manager.bank_client = bank_query
+            self.tx_manager.feemarket_client = feemarket_query
+        elif self.wallet is not None:
             self.tx_manager = TxManager(
                 wallet=self.wallet,
                 tx_client=tx_query,
@@ -105,6 +133,7 @@ class AlloraRPCClient:
                 bank_client=bank_query,
                 feemarket_client=feemarket_query,
                 config=self.network,
+                reconnect_callback=self._reconnect_grpc,
             )
 
         self.auth       = AuthClient(query_client=auth_query, tx_manager=self.tx_manager)
@@ -115,10 +144,47 @@ class AlloraRPCClient:
         self.mint       = MintClient(query_client=mint_query)
         self.feemarket  = FeemarketClient(query_client=feemarket_query)
 
-        if self.network.websocket_url is not None:
-            self.events = AlloraWebsocketSubscriber(self.network.websocket_url)
-        
-        logger.debug(f"Initialized Allora client for {self.network.chain_id}")
+
+    async def _reconnect_grpc(self):
+        """
+        Close the current grpclib.Channel and dial a fresh one, then re-bind
+        all the gRPC stubs (and the TxManager's stub references) to the new
+        channel.
+
+        Called from TxManager when it observes a transport-layer failure
+        (Cloudflare half-close, stream reset, server "Unavailable"). The
+        caller is the only thing that knows the channel is dead — there's
+        no notification from grpclib itself, since grpclib.Channel has no
+        keepalive or connectivity-state machine.
+
+        IMPORTANT: callers that captured a stub reference (e.g. via
+        `self.tx`, `self.bank`, etc.) BEFORE the reconnect will continue
+        holding the new stub because the Client* wrappers reference
+        TxManager / query_client by attribute, and we mutate those in
+        place above. New invocations against `self.tx.broadcast_tx(...)`
+        will hit the new channel. Direct references to a Stub instance
+        (rare) will still point at the dead one.
+
+        This is REST-protocol-aware: if the configured URL is REST-only,
+        there is no gRPC channel to recycle, and this is a no-op (the
+        REST clients use pooled HTTP and don't have the same problem).
+        """
+        if self._parsed_url.protocol != Protocol.GRPC:
+            logger.debug("Reconnect called but URL is REST-only — no gRPC channel to recycle")
+            return
+
+        old = self.grpc_client
+        logger.warning(f"Reconnecting gRPC channel to {self.network.url}")
+        try:
+            if old is not None:
+                old.close()
+        except Exception as exc:
+            # Closing a dead channel can itself raise; log and continue
+            logger.debug(f"Closing old gRPC channel raised: {exc}")
+
+        # Clear the reference so _build_clients dials a fresh one
+        self.grpc_client = None
+        self._build_clients()
     
 
     def _initialize_wallet(self, wallet: Optional[AlloraWalletConfig]):

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 from enum import Enum
-import grpc
+from grpclib.exceptions import GRPCError
 from datetime import datetime, timedelta
 from decimal import Decimal
 import logging
@@ -252,15 +252,18 @@ class TxManager:
             # Add a 20% safety margin to the estimate
             return int(gas_used * 1.2)
             
-        except grpc.RpcError as e:
-            error_details = e.details() if hasattr(e, 'details') else str(e)
+        except GRPCError as e:
+            # grpclib.GRPCError.message is the upstream-provided message string;
+            # .details is an optional attribute (often None) — NOT a callable
+            # (this used to call .details() on the wrong exception type).
+            error_details = e.message or str(e)
             logger.error(f"Simulation failed: {error_details}")
-            
+
             # Check for common errors
-            error_str = str(error_details).lower() if error_details else ""
+            error_str = error_details.lower()
             if "account sequence mismatch" in error_str:
                 raise AccountSequenceMismatchError(f"Sequence mismatch during simulation: {error_details}")
-            
+
             raise Exception(f"Transaction simulation failed: {error_details}")
         except Exception as e:
             logger.error(f"Simulation error: {e}")
@@ -434,9 +437,12 @@ class TxManager:
             if resp is None or resp.tx_response is None:
                 raise TxNotFoundError()
             return resp
-        except grpc.RpcError as e:
-            details = e.details()
-            if details is not None and "not found" in details:
+        except GRPCError as e:
+            # See note in _estimate_gas: grpclib.GRPCError.message is the
+            # upstream string (often "tx <hash> not found" for NOT_FOUND).
+            # .details is NOT callable; .message is the textual payload.
+            details = e.message or ""
+            if "not found" in details:
                 raise TxNotFoundError() from e
             raise
         except RuntimeError as e:

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -307,14 +307,18 @@ class TxManager:
             # .details is an optional attribute (often None) — NOT a callable
             # (this used to call .details() on the wrong exception type).
             error_details = e.message or str(e)
+            status_name = e.status.name if e.status is not None else "UNKNOWN"
 
             # Transport-layer failure: surface as GRPCTransportError so the
             # retry loop can force a channel reconnect.
             if _is_grpclib_transport_error(e):
-                logger.warning(f"Simulation hit gRPC transport failure: {error_details}")
+                logger.warning(
+                    f"Simulation hit gRPC transport failure "
+                    f"(grpc_status={status_name}): {error_details}"
+                )
                 raise GRPCTransportError(f"transport failure during simulation: {error_details}") from e
 
-            logger.error(f"Simulation failed: {error_details}")
+            logger.error(f"Simulation failed (grpc_status={status_name}): {error_details}")
 
             # Check for common errors
             error_str = error_details.lower()
@@ -371,7 +375,7 @@ class TxManager:
                 gas_multiplier = 1.0 + (attempt * 0.3)
                 if attempt == pending.max_retries or (pending.timeout and start + pending.timeout < datetime.now()):
                     raise Exception("Transaction failed after multiple attempts due to insufficient gas")
-                logger.debug(f"Gas estimation too low, retrying with higher gas (attempt {attempt + 2})")
+                logger.warning(f"Gas estimation too low, retrying with higher gas (attempt {attempt + 2})")
                 continue
 
             except InsufficientFeesError:
@@ -382,7 +386,7 @@ class TxManager:
                 fee_multiplier = 1.0 + attempt * 0.5
                 if attempt == pending.max_retries or (pending.timeout and start + pending.timeout < datetime.now()):
                     raise Exception("Transaction failed after multiple attempts due to insufficient fees")
-                logger.debug("Insufficient fees, retrying with refreshed gas price...")
+                logger.warning("Insufficient fees, retrying with refreshed gas price...")
                 continue
 
             except AccountSequenceMismatchError:
@@ -390,7 +394,7 @@ class TxManager:
                 # TODO: maybe build a nonce manager?
                 if attempt == pending.max_retries or (pending.timeout and start + pending.timeout < datetime.now()):
                     raise Exception("Transaction failed after multiple attempts due to repeated account sequence mismatches")
-                logger.debug("Account sequence mismatch, retrying...")
+                logger.warning("Account sequence mismatch, retrying...")
                 continue
 
             except TxTimeoutError:
@@ -398,7 +402,7 @@ class TxManager:
                     logger.error("Transaction timed out after multiple attempts")
                     pending._final_future.set_exception(TxTimeoutError())
                     return
-                logger.debug(f"Transaction timed out, retrying (attempt {attempt + 2})...")
+                logger.warning(f"Transaction timed out, retrying (attempt {attempt + 2})...")
                 continue
 
             except GRPCTransportError as err:

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 from enum import Enum
-from grpclib.exceptions import GRPCError
+from grpclib.const import Status
+from grpclib.exceptions import GRPCError, StreamTerminatedError
 from datetime import datetime, timedelta
 from decimal import Decimal
 import logging
@@ -101,6 +102,48 @@ class TxNotFoundError(Exception):
 
 class TxTimeoutError(Exception):
     pass
+
+
+class GRPCTransportError(Exception):
+    """
+    A gRPC transport-layer failure that may be recoverable by re-dialing the
+    underlying channel. Raised when the SDK observes one of:
+      - grpclib.StreamTerminatedError (HTTP/2 stream killed)
+      - grpclib.GRPCError with Status.UNAVAILABLE (server-reported "go away")
+      - grpclib.GRPCError whose message looks like an upstream CDN/LB
+        half-close ("connection reset by peer", "unexpected EOF", etc.)
+
+    The retry loop in _attempt_submissions catches this type and forces a
+    channel reconnect before the next attempt. Without this class, transport
+    failures fell into the generic 'except Exception' block which failed the
+    whole transaction with zero retries.
+    """
+    pass
+
+
+def _is_grpclib_transport_error(exc: BaseException) -> bool:
+    """
+    Classify whether a grpclib exception represents a transport-layer failure
+    that warrants closing-and-redialing the channel.
+
+    Mirrors the logic in lib/errors.go isGRPCTransportError() from the Go
+    offchain-node fix — same scenarios, same response (treat as switching
+    event). Substrings chosen to match grpclib's wrapping of the underlying
+    socket/HTTP2 errors observed in production.
+    """
+    if isinstance(exc, StreamTerminatedError):
+        return True
+    if isinstance(exc, GRPCError):
+        if exc.status == Status.UNAVAILABLE:
+            return True
+        msg = (exc.message or "").lower()
+        if "connection reset by peer" in msg:
+            return True
+        if "connection timed out" in msg:
+            return True
+        if "unexpected eof" in msg:
+            return True
+    return False
 
 
 class TxManager:
@@ -257,6 +300,13 @@ class TxManager:
             # .details is an optional attribute (often None) — NOT a callable
             # (this used to call .details() on the wrong exception type).
             error_details = e.message or str(e)
+
+            # Transport-layer failure: surface as GRPCTransportError so the
+            # retry loop can force a channel reconnect.
+            if _is_grpclib_transport_error(e):
+                logger.warning(f"Simulation hit gRPC transport failure: {error_details}")
+                raise GRPCTransportError(f"transport failure during simulation: {error_details}") from e
+
             logger.error(f"Simulation failed: {error_details}")
 
             # Check for common errors
@@ -265,6 +315,10 @@ class TxManager:
                 raise AccountSequenceMismatchError(f"Sequence mismatch during simulation: {error_details}")
 
             raise Exception(f"Transaction simulation failed: {error_details}")
+        except StreamTerminatedError as e:
+            # grpclib's HTTP/2-stream-killed exception — also a transport failure.
+            logger.warning(f"Simulation hit gRPC stream termination: {e}")
+            raise GRPCTransportError(f"stream terminated during simulation: {e}") from e
         except Exception as e:
             logger.error(f"Simulation error: {e}")
             raise
@@ -340,6 +394,35 @@ class TxManager:
                 logger.debug(f"Transaction timed out, retrying (attempt {attempt + 2})...")
                 continue
 
+            except GRPCTransportError as err:
+                # Transport-layer failure (Cloudflare half-close, stream
+                # reset, server "Unavailable"). The current grpclib.Channel
+                # is likely dead. Force a reconnect before retrying.
+                if attempt == pending.max_retries or (pending.timeout and start + pending.timeout < datetime.now()):
+                    logger.error(f"Transaction failed after max retries due to gRPC transport failure: {err}")
+                    pending._final_future.set_exception(err)
+                    return
+                logger.warning(f"gRPC transport failure on attempt {attempt + 1}, reconnecting and retrying: {err}")
+                await self._on_transport_failure()
+                continue
+
+            except (GRPCError, StreamTerminatedError) as err:
+                # Defensive net: a transport-classified grpclib error escaped
+                # without being wrapped in GRPCTransportError (e.g. raised
+                # from broadcast_tx or account_info, not _estimate_gas/_get_tx).
+                # Treat the same as GRPCTransportError if it classifies as one.
+                if _is_grpclib_transport_error(err):
+                    if attempt == pending.max_retries or (pending.timeout and start + pending.timeout < datetime.now()):
+                        logger.error(f"Transaction failed after max retries due to gRPC transport failure: {err}")
+                        pending._final_future.set_exception(GRPCTransportError(str(err)))
+                        return
+                    logger.warning(f"gRPC transport failure on attempt {attempt + 1} (unwrapped), reconnecting and retrying: {err}")
+                    await self._on_transport_failure()
+                    continue
+                # Non-transport grpclib error → fall through to generic Exception handler below
+                pending._final_future.set_exception(err)
+                return
+
             except Exception as err:
                 pending._final_future.set_exception(err)
                 return
@@ -410,6 +493,22 @@ class TxManager:
 
         return tx_hash, gas_limit, fee
 
+    async def _on_transport_failure(self):
+        """
+        Hook called by the retry loop when a gRPC transport error is observed.
+
+        Commit 3 wires this up to actually close-and-redial the channel.
+        Until then this is a no-op marker: the retry loop will retry, but
+        on a likely-dead channel, so the next attempt may still fail.
+        Logged at warning level so the dead-channel-retry situation is at
+        least visible.
+        """
+        logger.warning(
+            "Transport-failure recovery hook fired (no-op stub — channel "
+            "reconnect not yet wired up; next attempt will use the same "
+            "underlying channel)"
+        )
+
     async def wait_for_tx(self,
         hash: str,
         timeout: Optional[Union[int, float, timedelta]] = None,
@@ -444,7 +543,14 @@ class TxManager:
             details = e.message or ""
             if "not found" in details:
                 raise TxNotFoundError() from e
+            # Transport-layer failure during a tx-status poll: surface as
+            # GRPCTransportError so the caller (wait_for_tx → its caller)
+            # can choose to reconnect rather than tearing down the wait.
+            if _is_grpclib_transport_error(e):
+                raise GRPCTransportError(f"transport failure during get_tx: {details}") from e
             raise
+        except StreamTerminatedError as e:
+            raise GRPCTransportError(f"stream terminated during get_tx: {e}") from e
         except RuntimeError as e:
             details = str(e)
             if "tx" in details and "not found" in details:

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -5,7 +5,7 @@ from grpclib.exceptions import GRPCError, StreamTerminatedError
 from datetime import datetime, timedelta
 from decimal import Decimal
 import logging
-from typing import Any, Optional, Union, Dict, cast
+from typing import Any, Awaitable, Callable, Optional, Union, Dict, cast
 from google.protobuf.message import Message
 
 from cosmpy.aerial.wallet import LocalWallet
@@ -157,6 +157,7 @@ class TxManager:
         config: AlloraNetworkConfig,
         query_interval_secs: int = 2,
         query_timeout_secs: int = 5,
+        reconnect_callback: Optional[Callable[[], Awaitable[None]]] = None,
     ):
         self.wallet = wallet
         self.tx_client = tx_client
@@ -167,6 +168,12 @@ class TxManager:
         self.query_interval_secs = query_interval_secs
         self.query_timeout_secs = query_timeout_secs
         self.parent_tx_id = 0
+        # If set, called by the retry loop when a transport failure is
+        # detected. The callback is expected to close the current channel,
+        # dial a fresh one, and re-bind the stub references on this
+        # TxManager (tx_client, auth_client, bank_client, feemarket_client).
+        # AlloraRPCClient injects this; tests may leave it None for a no-op.
+        self._reconnect_callback = reconnect_callback
 
         self._default_gas_limits = {
             "/emissions.v9.InsertWorkerPayloadRequest": 250000,
@@ -497,17 +504,32 @@ class TxManager:
         """
         Hook called by the retry loop when a gRPC transport error is observed.
 
-        Commit 3 wires this up to actually close-and-redial the channel.
-        Until then this is a no-op marker: the retry loop will retry, but
-        on a likely-dead channel, so the next attempt may still fail.
-        Logged at warning level so the dead-channel-retry situation is at
-        least visible.
+        If a reconnect_callback was injected at construction time
+        (AlloraRPCClient does this in production), call it to close the
+        current grpclib.Channel, dial a fresh one, and re-bind the stub
+        references on this TxManager. The callback is responsible for the
+        rebinding because TxManager doesn't own the Channel directly.
+
+        If no callback is configured (e.g. in unit tests, or if TxManager
+        is wired up standalone), this is a no-op marker that at least makes
+        the dead-channel-retry situation visible in logs.
         """
-        logger.warning(
-            "Transport-failure recovery hook fired (no-op stub — channel "
-            "reconnect not yet wired up; next attempt will use the same "
-            "underlying channel)"
-        )
+        if self._reconnect_callback is None:
+            logger.warning(
+                "Transport-failure observed but no reconnect_callback "
+                "configured — next attempt will reuse the same (likely "
+                "dead) channel"
+            )
+            return
+        try:
+            await self._reconnect_callback()
+            logger.info("gRPC channel reconnected after transport failure")
+        except Exception as exc:
+            # The reconnect itself failed (DNS, TCP, TLS, whatever). The
+            # retry loop will still try the next attempt — the channel may
+            # be dead, but we don't want the failed-reconnect exception to
+            # cascade and abort the whole submission. Surface as warning.
+            logger.warning(f"gRPC channel reconnect failed: {exc}")
 
     async def wait_for_tx(self,
         hash: str,

--- a/tests/test_tx_manager_grpclib_errors.py
+++ b/tests/test_tx_manager_grpclib_errors.py
@@ -1,0 +1,108 @@
+"""
+Tests for TxManager error-classification paths that catch grpclib exceptions.
+
+These exist primarily as regression tests: the previous version of this code
+imported `grpc` (grpcio) and caught `grpc.RpcError`, but the channel underneath
+is `grpclib.client.Channel`. `grpclib.GRPCError` does NOT inherit from
+`grpc.RpcError`, so those except blocks were dead code in production.
+"""
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from grpclib.const import Status
+from grpclib.exceptions import GRPCError
+
+from allora_sdk.rpc_client.config import AlloraNetworkConfig
+from allora_sdk.rpc_client.tx_manager import (
+    TxManager,
+    TxNotFoundError,
+    AccountSequenceMismatchError,
+)
+
+
+def _make_manager(*, tx_client=None, auth_client=None) -> TxManager:
+    """Construct a TxManager with mostly-Mock collaborators."""
+    return TxManager(
+        wallet=Mock(),
+        tx_client=tx_client or Mock(),
+        auth_client=auth_client or Mock(),
+        bank_client=Mock(),
+        feemarket_client=Mock(),
+        config=AlloraNetworkConfig.testnet(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_tx_raises_tx_not_found_on_grpclib_not_found_error():
+    """
+    `_get_tx` must convert grpclib.GRPCError(Status.NOT_FOUND) to TxNotFoundError.
+    Regression: pre-fix this was matched only by accident via the bare
+    `except Exception` fallback's substring check on str(e).
+    """
+    tx_client = Mock()
+    tx_client.get_tx = AsyncMock(
+        side_effect=GRPCError(Status.NOT_FOUND, "tx ABC123 not found", None)
+    )
+    mgr = _make_manager(tx_client=tx_client)
+
+    with pytest.raises(TxNotFoundError):
+        await mgr._get_tx("ABC123")
+
+
+@pytest.mark.asyncio
+async def test_get_tx_reraises_grpclib_error_when_not_a_not_found():
+    """A non-NOT_FOUND grpclib error should propagate untouched."""
+    tx_client = Mock()
+    err = GRPCError(Status.UNAVAILABLE, "upstream is down", None)
+    tx_client.get_tx = AsyncMock(side_effect=err)
+    mgr = _make_manager(tx_client=tx_client)
+
+    with pytest.raises(GRPCError) as exc_info:
+        await mgr._get_tx("ABC123")
+    assert exc_info.value is err
+
+
+@pytest.mark.asyncio
+async def test_get_tx_returns_response_on_success():
+    """Happy path: get_tx returns a populated response unchanged."""
+    fake_resp = Mock(tx_response=Mock())
+    tx_client = Mock()
+    tx_client.get_tx = AsyncMock(return_value=fake_resp)
+    mgr = _make_manager(tx_client=tx_client)
+
+    assert await mgr._get_tx("ABC123") is fake_resp
+
+
+def test_grpclib_error_does_not_inherit_from_grpc_rpcerror():
+    """
+    Regression assertion for the original bug: GRPCError (from grpclib, the
+    library actually used by AlloraRPCClient) MUST NOT be a subclass of
+    grpc.RpcError (from grpcio). Anyone who imports `grpc` and writes
+    `except grpc.RpcError` while using grpclib is writing dead code.
+
+    This test pins down that fact so we don't accidentally re-introduce
+    the bug if grpc/grpclib internals change. The previous version of
+    tx_manager.py imported `grpc` and caught `grpc.RpcError` — both blocks
+    were silently dead in production for the entire lifetime of the SDK.
+    """
+    import grpc as grpcio_mod  # type: ignore[import-not-found]
+    assert not issubclass(GRPCError, grpcio_mod.RpcError)
+
+
+def test_grpclib_error_message_attribute_is_string_not_method():
+    """
+    Pin down that grpclib.GRPCError.message is an attribute, not a method.
+
+    The pre-fix code called `e.details()` which would have crashed with
+    TypeError if it had ever been reached (`grpclib.GRPCError.details` is
+    an attribute that defaults to None, also NOT callable). The `.message`
+    attribute is the textual payload from the server and is the correct
+    accessor for substring-matching error text.
+    """
+    err = GRPCError(Status.NOT_FOUND, "tx ABC123 not found", None)
+    # message is the carried string, accessed as attribute
+    assert err.message == "tx ABC123 not found"
+    assert isinstance(err.message, str)
+    # details is None here (no trailing metadata provided), NOT callable
+    assert err.details is None
+    assert not callable(err.details)

--- a/tests/test_tx_manager_grpclib_errors.py
+++ b/tests/test_tx_manager_grpclib_errors.py
@@ -178,3 +178,62 @@ def test_grpclib_error_message_attribute_is_string_not_method():
     # details is None here (no trailing metadata provided), NOT callable
     assert err.details is None
     assert not callable(err.details)
+
+
+@pytest.mark.asyncio
+async def test_on_transport_failure_invokes_reconnect_callback():
+    """
+    If a reconnect_callback is configured on TxManager, _on_transport_failure
+    must call it. This is how the channel actually gets re-dialed on a
+    transport-class failure.
+    """
+    callback_calls: list[None] = []
+
+    async def fake_reconnect():
+        callback_calls.append(None)
+
+    mgr = TxManager(
+        wallet=Mock(),
+        tx_client=Mock(),
+        auth_client=Mock(),
+        bank_client=Mock(),
+        feemarket_client=Mock(),
+        config=AlloraNetworkConfig.testnet(),
+        reconnect_callback=fake_reconnect,
+    )
+
+    await mgr._on_transport_failure()
+    assert len(callback_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_on_transport_failure_is_noop_without_callback():
+    """If no callback is configured, _on_transport_failure logs and returns cleanly."""
+    mgr = _make_manager()  # no callback
+    # Must not raise; pre-fix this was a no-op stub anyway, just make sure
+    # the absence of a callback is handled gracefully.
+    await mgr._on_transport_failure()
+
+
+@pytest.mark.asyncio
+async def test_on_transport_failure_swallows_reconnect_errors():
+    """
+    If the reconnect callback itself raises, _on_transport_failure must
+    NOT propagate the error. The retry loop is going to retry anyway; we
+    don't want a failed reconnect to cascade into a failed submission.
+    """
+    async def failing_reconnect():
+        raise RuntimeError("DNS failed or something")
+
+    mgr = TxManager(
+        wallet=Mock(),
+        tx_client=Mock(),
+        auth_client=Mock(),
+        bank_client=Mock(),
+        feemarket_client=Mock(),
+        config=AlloraNetworkConfig.testnet(),
+        reconnect_callback=failing_reconnect,
+    )
+
+    # Must not raise
+    await mgr._on_transport_failure()

--- a/tests/test_tx_manager_grpclib_errors.py
+++ b/tests/test_tx_manager_grpclib_errors.py
@@ -17,6 +17,8 @@ from allora_sdk.rpc_client.tx_manager import (
     TxManager,
     TxNotFoundError,
     AccountSequenceMismatchError,
+    GRPCTransportError,
+    _is_grpclib_transport_error,
 )
 
 
@@ -50,16 +52,86 @@ async def test_get_tx_raises_tx_not_found_on_grpclib_not_found_error():
 
 
 @pytest.mark.asyncio
-async def test_get_tx_reraises_grpclib_error_when_not_a_not_found():
-    """A non-NOT_FOUND grpclib error should propagate untouched."""
+async def test_get_tx_reraises_grpclib_error_when_not_a_not_found_and_not_transport():
+    """A non-NOT_FOUND, non-transport grpclib error should propagate untouched."""
     tx_client = Mock()
-    err = GRPCError(Status.UNAVAILABLE, "upstream is down", None)
+    err = GRPCError(Status.PERMISSION_DENIED, "permission denied", None)
     tx_client.get_tx = AsyncMock(side_effect=err)
     mgr = _make_manager(tx_client=tx_client)
 
     with pytest.raises(GRPCError) as exc_info:
         await mgr._get_tx("ABC123")
     assert exc_info.value is err
+
+
+@pytest.mark.asyncio
+async def test_get_tx_converts_unavailable_to_transport_error():
+    """grpclib UNAVAILABLE → GRPCTransportError for the retry loop to react on."""
+    tx_client = Mock()
+    tx_client.get_tx = AsyncMock(
+        side_effect=GRPCError(Status.UNAVAILABLE, "upstream is down", None)
+    )
+    mgr = _make_manager(tx_client=tx_client)
+
+    with pytest.raises(GRPCTransportError):
+        await mgr._get_tx("ABC123")
+
+
+@pytest.mark.asyncio
+async def test_get_tx_converts_connection_reset_to_transport_error():
+    """grpclib error with 'connection reset by peer' in message → GRPCTransportError."""
+    tx_client = Mock()
+    tx_client.get_tx = AsyncMock(
+        side_effect=GRPCError(
+            Status.UNKNOWN,
+            "error reading from server: read tcp 10.0.0.1:443: read: connection reset by peer",
+            None,
+        )
+    )
+    mgr = _make_manager(tx_client=tx_client)
+
+    with pytest.raises(GRPCTransportError):
+        await mgr._get_tx("ABC123")
+
+
+@pytest.mark.asyncio
+async def test_get_tx_converts_stream_terminated_to_transport_error():
+    """grpclib StreamTerminatedError → GRPCTransportError."""
+    from grpclib.exceptions import StreamTerminatedError
+    tx_client = Mock()
+    tx_client.get_tx = AsyncMock(side_effect=StreamTerminatedError("Connection lost"))
+    mgr = _make_manager(tx_client=tx_client)
+
+    with pytest.raises(GRPCTransportError):
+        await mgr._get_tx("ABC123")
+
+
+def test_is_grpclib_transport_error_classification():
+    """Direct unit test of the transport-classifier helper."""
+    from grpclib.exceptions import StreamTerminatedError
+
+    # Positive cases
+    assert _is_grpclib_transport_error(StreamTerminatedError("anything"))
+    assert _is_grpclib_transport_error(GRPCError(Status.UNAVAILABLE, "go away", None))
+    assert _is_grpclib_transport_error(
+        GRPCError(Status.UNKNOWN, "read tcp ...: connection reset by peer", None)
+    )
+    assert _is_grpclib_transport_error(
+        GRPCError(Status.UNKNOWN, "code = Unavailable desc = unexpected EOF", None)
+    )
+
+    # Negative cases — not transport
+    assert not _is_grpclib_transport_error(
+        GRPCError(Status.NOT_FOUND, "tx ABC not found", None)
+    )
+    assert not _is_grpclib_transport_error(
+        GRPCError(Status.INVALID_ARGUMENT, "account sequence mismatch", None)
+    )
+    assert not _is_grpclib_transport_error(
+        GRPCError(Status.PERMISSION_DENIED, "denied", None)
+    )
+    assert not _is_grpclib_transport_error(RuntimeError("unrelated"))
+    assert not _is_grpclib_transport_error(Exception("unrelated"))
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,6 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "pyyaml", marker = "extra == 'codegen'" },
     { name = "requests" },
-    { name = "requests", specifier = "~=2.32" },
     { name = "requests-async", specifier = ">=0.2.4" },
     { name = "starlette", marker = "extra == 'dev'" },
     { name = "tox", marker = "extra == 'dev'" },


### PR DESCRIPTION
# Fix grpclib error handling — wrong exception type + no transport recovery (DEVOP-595)

Parent diagnostic: [DEVOP-593](https://linear.app/alloralabs/issue/DEVOP-593/diagnostic-silent-stall-rpc-failures-across-allora-offchain-stack-go)
Fixes: [DEVOP-595](https://linear.app/alloralabs/issue/DEVOP-595/fix-allora-sdk-py-grpclib-error-handling-wrong-exception-type-no)
Sibling PR: see allora-offchain-node `fix/rpc-silent-stall` (DEVOP-594)

## What this fixes

Same class of silent-stall problem the Go offchain-node had, but worse: the Python SDK never had a working RPC error-handling path to begin with.

### Bug 1: `except grpc.RpcError` is dead code

`tx_manager.py` imported `grpc` (the `grpcio` library) and caught `grpc.RpcError` in two places — `_estimate_gas` and `_get_tx`. But the gRPC channel underneath is `grpclib.client.Channel` from the unrelated `grpclib` library. `grpclib.GRPCError` and `grpclib.StreamTerminatedError` inherit directly from `Exception`, NOT from `grpc.RpcError`.

Result: both `except grpc.RpcError` blocks were silent dead code for the entire lifetime of the SDK.

- `_estimate_gas`: account-sequence-mismatch detection during gas simulation never fired. Real grpclib errors fell into the bare `except Exception` below and re-raised without being converted to `AccountSequenceMismatchError`. The retry loop never refreshed the sequence number for the next attempt.
- `_get_tx`: `TxNotFoundError` detection "worked" only by accident — the bare `except Exception` fallback's substring match on `str(e)` caught it because `str(GRPCError)` happens to contain both `"tx"` and `"not found"`. Load-bearing accident.

Bonus latent bug: if anything had actually entered the `grpc.RpcError` block, `e.details()` would have crashed with `TypeError`. `grpclib`'s `GRPCError.details` is an attribute (defaulting to `None`), not a method.

### Bug 2: No retry on transport failure

The retry loop in `_attempt_submissions` catches specific cosmos-level errors but the bare `except Exception` on line 340 sets the future to the error and returns. One `grpclib.StreamTerminatedError` or `GRPCError(UNAVAILABLE)` mid-broadcast kills the whole tx with zero retries and no channel re-dial.

### Bug 3: `grpclib.Channel` has no keepalive, no reconnect, no pool

Verified empirically against `grpclib==0.4.8`:
```
Channel public methods: close, request
contains 'keepalive': False / 'reconnect': False / 'pool': False
```

When Cloudflare half-closes the HTTP/2 stream, the Channel object is dead and there's no recovery — unless the caller dials a new one.

### Pre-existing build break (prep commit)

`pyproject.toml` on `dev` was unbuildable: dependabot PR #64 introduced `"requests *"` which is invalid PEP 508 (a bare `*` is not a version specifier). `uv sync` / `pip install -e .` both failed. The same dep was also listed correctly on a different line, so just removing the broken entry restores the build. Isolated as its own commit so it can be cherry-picked or reverted independently.

## Changes (5 commits)

```
2fa9f9b fix(deps): remove invalid 'requests *' PEP 508 specifier from pyproject.toml
a90eaff fix(tx_manager): catch grpclib.GRPCError instead of grpc.RpcError (dead code)
55532b9 feat(tx_manager): GRPCTransportError + retry-loop handler for transport failures
bd4cd0a feat(client): wire AlloraRPCClient._reconnect_grpc as the TxManager recovery hook
13401c3 fix(tx_manager): align log levels with retry semantics + surface grpc_status
```

1. **Prep**: fix `pyproject.toml` so `make dev` works.
2. **Dead-code fix**: replace `import grpc` with `from grpclib.exceptions import GRPCError`. Fix `e.details()` → `e.message`. Add regression tests pinning down `GRPCError ∉ grpc.RpcError` and `GRPCError.message` is a string attribute (not callable).
3. **`GRPCTransportError` + retry-loop handler**:
   - New exception class for transport failures: `StreamTerminatedError`, `GRPCError(UNAVAILABLE)`, or `GRPCError` whose message contains `"connection reset by peer"`, `"connection timed out"`, or `"unexpected EOF"`.
   - New `_is_grpclib_transport_error(exc)` classifier — single source of truth for what counts as transport-class. Mirrors `lib/errors.go isGRPCTransportError()` from the Go-side fix.
   - `_attempt_submissions` retry loop gains an `except GRPCTransportError` branch that retries within the existing retry budget, calling `_on_transport_failure()` between attempts.
   - Defensive net for raw `GRPCError`/`StreamTerminatedError` that escapes from `broadcast_tx` or `account_info` paths.
4. **Reconnect wiring**: `AlloraRPCClient` now has `_reconnect_grpc()` that closes the dead `grpclib.Channel`, dials a fresh one, and re-binds all stub references — including `TxManager.tx_client`, `auth_client`, `bank_client`, `feemarket_client` — in place so the existing instances keep working. `TxManager.__init__` accepts an optional `reconnect_callback`. The reconnect path goes through a factored-out `_build_clients()` method so the initial-setup path and reconnect path can't drift.
5. **Log levels & grpc_status surface**: retry-attempt logs promoted from `debug` to `warning` (so dashboards see the retries, not just the final outcome). `grpc_status=<Status.name>` added to simulation error logs so dashboards can group by class without substring-matching.

## Verification done locally

```
uv run pytest tests/ --ignore=tests/test_api_client_integration.py
======================== 16 passed in 0.48s ========================
```

3 pre-existing tests + 13 new tests across:
- `_get_tx` conversion paths (NOT_FOUND → `TxNotFoundError`; UNAVAILABLE → `GRPCTransportError`; `connection reset by peer` → `GRPCTransportError`; `StreamTerminatedError` → `GRPCTransportError`; non-transport non-not-found propagates untouched; happy path)
- `_is_grpclib_transport_error` classifier (4 positive + 5 negative cases)
- `_on_transport_failure` hook (invokes callback exactly once; clean no-op without callback; swallows callback failures)
- Regression assertions: `GRPCError ∉ grpc.RpcError` and `GRPCError.message` is `str` not callable

Integration tests not run (require testnet API access).

## Stub reference caveat

Callers that captured a direct `Stub` reference BEFORE a reconnect (e.g. `my_stub = client.tx_manager.tx_client; ...; await my_stub.broadcast_tx(...)`) will still hit the dead channel. New invocations through `client.tx`, `client.bank`, etc. always hit the latest channel because the `Client*` wrappers reference `TxManager` / `query_client` by attribute and the reconnect path mutates those in place. Documented in `AlloraRPCClient._reconnect_grpc` docstring.

## Concurrency note

Stub references on `TxManager` are reassigned without a lock. Safe under the current design because `submit_transaction` is sequential per `TxManager` instance (no parallel `_attempt_submissions` loops on the same manager). If that invariant ever changes, the stub swap will need to move under a lock or be made copy-on-write.

## Out of scope (tracked in parent DEVOP-593)

- Multi-endpoint URL list in `AlloraNetworkConfig` (deferred — `cosmpy.NetworkConfig` only accepts a single URL)
- Switching from `grpclib` to `grpcio` (deferred — would require regenerating all betterproto-based client stubs; the proto pipeline is fragile)
- Broader `pyproject.toml` cleanup (triple-listed `requests`, discontinued `requests-async` dep)

## Recommended merge order

Merge the Go-side fix first (DEVOP-594). Validate on a testnet canary pod for 24h. If the diagnosis is correct, the same pattern works for this SDK and we can merge with confidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gRPC error handling in the Python SDK by catching `grpclib` exceptions, classifying transport failures, and auto‑reconnecting the channel to retry broadcasts, preventing silent stalls and mid‑broadcast failures (DEVOP-595). Also removes an invalid `requests *` dependency and updates `uv.lock` to restore installs and CI.

- **Bug Fixes**
  - Catch `grpclib.GRPCError`/`StreamTerminatedError` instead of `grpc.RpcError`; use `.message` (not `.details()`).
  - Add `GRPCTransportError` and `_is_grpclib_transport_error(...)` to treat UNAVAILABLE, stream resets, timeouts, and unexpected EOF as transport failures.
  - Retry transport failures in `_attempt_submissions` and call `AlloraRPCClient._reconnect_grpc()` to redial `grpclib.Channel` and rebind stubs in place.
  - Promote retry logs to warning and include `grpc_status=<Status>` in error logs for easier triage.
  - Convert tx lookup NOT_FOUND to `TxNotFoundError` and restore sequence‑mismatch handling during simulation.
  - Regenerate `uv.lock` after removing the invalid dependency to keep `uv sync --locked` green.

- **Migration**
  - Do not cache direct gRPC stub instances across reconnects; use `client.tx`, `client.bank`, etc., which always point to the current channel.

<sup>Written for commit 11a3c4070000ae6e7fa21a2d62d1644bf2e32148. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

