### PR TITLE
Support for multi-value topics ENGN-8845

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(GOOGLEAPIS_DIR)/.git:
 
 $(ALLORA_CHAIN_DIR)/.git:
 	rm -rf "$(ALLORA_CHAIN_DIR)"
-	git clone --depth 1 --single-branch --branch v0.12.2 \
+	git clone --depth 1 --single-branch --branch alek/classification \
 	  https://github.com/allora-network/allora-chain "$(ALLORA_CHAIN_DIR)"
 
 .PHONY: proto-deps
@@ -88,7 +88,7 @@ proto-deps-update:
 	git -C "$(COSMOS_SDK_DIR)" fetch --depth 1 origin v0.50.13 && git -C "$(COSMOS_SDK_DIR)" reset --hard FETCH_HEAD
 	git -C "$(FEEMARKET_DIR)" fetch --depth 1 origin v1.1.1 && git -C "$(FEEMARKET_DIR)" reset --hard FETCH_HEAD
 	git -C "$(GOOGLEAPIS_DIR)" fetch --depth 1 origin master && git -C "$(GOOGLEAPIS_DIR)" reset --hard FETCH_HEAD
-	git -C "$(ALLORA_CHAIN_DIR)" fetch --depth 1 origin v0.12.2 && git -C "$(ALLORA_CHAIN_DIR)" reset --hard FETCH_HEAD
+	git -C "$(ALLORA_CHAIN_DIR)" fetch --depth 1 origin alek/classification && git -C "$(ALLORA_CHAIN_DIR)" reset --hard FETCH_HEAD
 
 # --- Ensure output dirs exist (order-only)
 $(ALLORA_PROTOS_DIR):
@@ -160,6 +160,7 @@ $(INTERFACE_STAMP): \
 		--out "$(INTERFACE_OUT_DIR)" \
 		--include-tags \
 			emissions.v9 \
+			emissions.v10 \
 			mint.v5 \
 			cosmos.tx \
 			cosmos.base.tendermint.v1beta1 \
@@ -201,6 +202,7 @@ $(REST_STAMP): \
 		--out "$(REST_CLIENT_OUT_DIR)" \
 		--include-tags \
 			emissions.v9 \
+			emissions.v10 \
 			mint.v5 \
 			cosmos.tx \
 			cosmos.base.tendermint.v1beta1 \
@@ -244,6 +246,7 @@ $(GRPC_STAMP): \
 		--out "$(GRPC_WRAPPER_OUT_DIR)" \
 		--include-tags \
 			emissions.v9 \
+			emissions.v10 \
 			mint.v5 \
 			cosmos.tx \
 			cosmos.base.tendermint.v1beta1 \
@@ -283,4 +286,3 @@ distclean: clean
 .PHONY: test
 test:
 	tox run-parallel
-

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(GOOGLEAPIS_DIR)/.git:
 
 $(ALLORA_CHAIN_DIR)/.git:
 	rm -rf "$(ALLORA_CHAIN_DIR)"
-	git clone --depth 1 --single-branch --branch alek/classification \
+	git clone --depth 1 --single-branch --branch dev \
 	  https://github.com/allora-network/allora-chain "$(ALLORA_CHAIN_DIR)"
 
 .PHONY: proto-deps
@@ -88,7 +88,7 @@ proto-deps-update:
 	git -C "$(COSMOS_SDK_DIR)" fetch --depth 1 origin v0.50.13 && git -C "$(COSMOS_SDK_DIR)" reset --hard FETCH_HEAD
 	git -C "$(FEEMARKET_DIR)" fetch --depth 1 origin v1.1.1 && git -C "$(FEEMARKET_DIR)" reset --hard FETCH_HEAD
 	git -C "$(GOOGLEAPIS_DIR)" fetch --depth 1 origin master && git -C "$(GOOGLEAPIS_DIR)" reset --hard FETCH_HEAD
-	git -C "$(ALLORA_CHAIN_DIR)" fetch --depth 1 origin alek/classification && git -C "$(ALLORA_CHAIN_DIR)" reset --hard FETCH_HEAD
+	git -C "$(ALLORA_CHAIN_DIR)" fetch --depth 1 origin dev && git -C "$(ALLORA_CHAIN_DIR)" reset --hard FETCH_HEAD
 
 # --- Ensure output dirs exist (order-only)
 $(ALLORA_PROTOS_DIR):

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(GOOGLEAPIS_DIR)/.git:
 
 $(ALLORA_CHAIN_DIR)/.git:
 	rm -rf "$(ALLORA_CHAIN_DIR)"
-	git clone --depth 1 --single-branch --branch dev \
+	git clone --depth 1 --single-branch --branch v0.17.0 \
 	  https://github.com/allora-network/allora-chain "$(ALLORA_CHAIN_DIR)"
 
 .PHONY: proto-deps
@@ -88,7 +88,7 @@ proto-deps-update:
 	git -C "$(COSMOS_SDK_DIR)" fetch --depth 1 origin v0.50.13 && git -C "$(COSMOS_SDK_DIR)" reset --hard FETCH_HEAD
 	git -C "$(FEEMARKET_DIR)" fetch --depth 1 origin v1.1.1 && git -C "$(FEEMARKET_DIR)" reset --hard FETCH_HEAD
 	git -C "$(GOOGLEAPIS_DIR)" fetch --depth 1 origin master && git -C "$(GOOGLEAPIS_DIR)" reset --hard FETCH_HEAD
-	git -C "$(ALLORA_CHAIN_DIR)" fetch --depth 1 origin dev && git -C "$(ALLORA_CHAIN_DIR)" reset --hard FETCH_HEAD
+	git -C "$(ALLORA_CHAIN_DIR)" fetch --depth 1 origin v0.17.0 && git -C "$(ALLORA_CHAIN_DIR)" reset --hard FETCH_HEAD
 
 # --- Ensure output dirs exist (order-only)
 $(ALLORA_PROTOS_DIR):

--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ inference_worker = AlloraWorker.inferer(
 
 ### Reputer Configuration
 
-Reputers evaluate inference quality by computing losses between ground truth and predictions. An simple reputer can be built with the SDK just as easily as an inference worker. The main difference, is that instead of the `run_model` callback we need to pass a `reputer_fn` which has the type `(context: RunContext, inference: float) -> float`. This function gets called once for each inference in the epoch (that is, the network inference, each individual worker's inference, and a few additional "one-out" inferences which the network uses for scoring). It is expected to obtain a ground truth value, compare it to the inference, and return a loss which is computed with the topic-defined loss function.
+Reputers evaluate inference quality by computing losses between ground truth and predictions. An simple reputer can be built with the SDK just as easily as an inference worker. The main difference, is that instead of the `run_model` callback we need to pass a `reputer_fn` which has the type `(context: RunContext, inference: dict[str, float]) -> float`. This function gets called once for each inference in the epoch (that is, the network inference, each individual worker's inference, and a few additional "one-out" inferences which the network uses for scoring). It is expected to obtain a ground truth value, compare it to the inference, and return a loss which is computed with the topic-defined loss function.
 
 In practice, it is often more convenient to have two separate callbacks:
 1. A ground truth function `get_ground_truth(context: RunContext) -> GroundTruthType` which only runs once per epoch.
-2. A loss function `loss(gt: GroundTruthType, inference: float) -> float`, which runs for every value in the inference bundle
+2. A loss function of the type `loss(gt: GroundTruthType, inference: float) -> float` for single-value topics, or of the type `loss(gt: GroundTruthType, inference: dict[str, float]) -> float` for multi-value topics, which runs for every value in the inference bundle.
 
-Note that the ground truth type does not need to agree with the inference type (`float`). That is useful for certain loss functions which require extra data. For example, the `czar` and `ztae` loss functions require a standard deviation of historical values, which can just be treated as part of the ground truth.
+Note that the ground truth type does not need to agree with the inference type. That is useful for certain loss functions which require extra data. For example, the `czar` and `ztae` loss functions require a standard deviation of historical values, which can just be treated as part of the ground truth.
 
-We provide a helper function `make_reputer_function` which takes two functions `get_ground_truth` and `loss_fn` as above and returns a `reputer_fn` that is suitable for passing to the Allora worker. It handles the caching of the ground truth, so that `get_ground_truth` only needs to be called once.
+We provide a helper function `make_reputer_function` which takes two functions `get_ground_truth` and `loss_fn` as above and returns a `reputer_fn` that is suitable for passing to the Allora worker. It handles the caching of the ground truth, so that `get_ground_truth` only needs to be called once per epoch.
 
 ```python
 def mse_loss(x: float, y: float) -> float:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ inference_worker = AlloraWorker.inferer(
 
 ### Reputer Configuration
 
-Reputers evaluate inference quality by computing losses between ground truth and predictions. An simple reputer can be built with the SDK just as easily as an inference worker. The main difference, is that instead of the `run_model` callback we need to pass a `reputer_fn` which has the type `(context: RunContext, inference: float) -> float`. This function gets called once for each inference in the epoch (that is, the network inference, each individual worker's inference, and a few additional "one-out" inferences which the network uses for scoring). It is expected to obtain a ground truth value, compare it to the inference, and return a loss which is computed with the topic-defined loss function. 
+Reputers evaluate inference quality by computing losses between ground truth and predictions. An simple reputer can be built with the SDK just as easily as an inference worker. The main difference, is that instead of the `run_model` callback we need to pass a `reputer_fn` which has the type `(context: RunContext, inference: float) -> float`. This function gets called once for each inference in the epoch (that is, the network inference, each individual worker's inference, and a few additional "one-out" inferences which the network uses for scoring). It is expected to obtain a ground truth value, compare it to the inference, and return a loss which is computed with the topic-defined loss function.
 
 In practice, it is often more convenient to have two separate callbacks:
 1. A ground truth function `get_ground_truth(context: RunContext) -> GroundTruthType` which only runs once per epoch.
@@ -249,9 +249,9 @@ client = AlloraRPCClient.from_env()
 # Query network data
 # Note: `height` is optional.  Defaults to the latest block on the chain.
 request = GetLatestRegretStdNormRequest(topic_id=123)
-response = client.emissions.query.get_latest_regret_std_norm(request, height=6200000) 
+response = client.emissions.query.get_latest_regret_std_norm(request, height=6200000)
 
-# Submit transactions  
+# Submit transactions
 response = await client.emissions.tx.insert_worker_payload(
     topic_id=1,
     inference_value="55000.0",
@@ -259,7 +259,7 @@ response = await client.emissions.tx.insert_worker_payload(
 )
 
 # WebSocket event subscriptions
-from allora_sdk.rpc_client.protos.emissions.v9 import EventWorkerSubmissionWindowOpened
+from allora_sdk.rpc_client.protos.emissions.v10 import EventWorkerSubmissionWindowOpened
 
 async def handle_event(event, block_height):
     print(f"New epoch: {event.topic_id} at block {block_height}")
@@ -291,7 +291,7 @@ Wire protocol is determined by the RPC url string passed to the config construct
 - `grpc+http(s)` will use the gRPC Protobuf client
 - `rest+http(s)` will use the Cosmos-LCD client
 
-- **Transaction support**: Fee estimation, signing, and broadcasting  
+- **Transaction support**: Fee estimation, signing, and broadcasting
 - **WebSocket events**: Real-time blockchain event subscriptions.  For a usage example, see the `AlloraWorker`
 - **Multi-chain**: Testnet and mainnet support come with batteries included, but there is maximal configurability.  Can be used with other Cosmos SDK chains.
 - **Type safety**: Full protobuf type and service definitions, codegen clients
@@ -325,7 +325,7 @@ asyncio.run(main())
 ### Features
 
 - **Price predictions**: BTC, ETH, SOL, etc. across multiple timeframes
-- **Topic index**: Browse all network topics and their metadata  
+- **Topic index**: Browse all network topics and their metadata
 - **Confidence intervals**: Access prediction uncertainty bounds
 - **Async/await**: Fully asynchronous API
 
@@ -424,7 +424,7 @@ The SDK uses two code generation systems:
 - Command: `make grpc`
 
 **REST Client Generation:**
-- Analyzes protobuf HTTP annotations to generate REST clients  
+- Analyzes protobuf HTTP annotations to generate REST clients
 - Matches gRPC client interfaces exactly
 - Sources: Same .proto files as above
 - Output: `src/allora_sdk/rpc_client/rest/`
@@ -441,13 +441,11 @@ source .venv/bin/activate
 make dev
 
 # After changes to .proto files
-rm -rf src/allora_sdk/rpc_client/rest
-rm -rf src/allora_sdk/rpc_client/grpc
-rm -rf src/allora_sdk/rpc_client/interfaces
-rm -rf src/allora_sdk/rpc_client/protos
+rm -rf src/allora_sdk/rpc_client/{rest,grpc,interfaces,protos}
+rm -rf proto-deps    # if chain version changed
 make dev
 
-# Run tests  
+# Run tests
 tox
 
 # Build wheel for distribution
@@ -457,8 +455,5 @@ make wheel      # or: uv build
 ### Dependencies
 
 - **Runtime dependencies**: Defined in `pyproject.toml` under `dependencies`
-- **Development dependencies**: Under `[project.optional-dependencies.dev]`  
+- **Development dependencies**: Under `[project.optional-dependencies.dev]`
 - **Code generation**: Under `[project.optional-dependencies.codegen]`
-
-
-

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -26,7 +26,7 @@ import allora_sdk.rpc_client.protos.cosmos.tx.v1beta1 as cosmos_tx_v1beta1
 import allora_sdk.rpc_client.protos.cosmos.auth.v1beta1 as cosmos_auth_v1beta1
 import allora_sdk.rpc_client.protos.cosmos.bank.v1beta1 as cosmos_bank_v1beta1
 import allora_sdk.rpc_client.protos.cosmos.staking.v1beta1 as cosmos_staking_v1beta1
-import allora_sdk.rpc_client.protos.emissions.v9 as emissions_v9
+import allora_sdk.rpc_client.protos.emissions.v10 as emissions_v10
 import allora_sdk.rpc_client.protos.feemarket.feemarket.v1 as feemarket_v1
 import allora_sdk.rpc_client.protos.mint.v5 as mint_v5
 import allora_sdk.rpc_client.rest as rest
@@ -91,7 +91,7 @@ class ReconnectingGRPCChannel(Channel):
 class AlloraRPCClient:
     """
     Main client for interacting with the Allora blockchain.
-    
+
     This class provides a high-level interface for blockchain operations
     including queries, transactions, and event subscriptions.
     """
@@ -107,7 +107,7 @@ class AlloraRPCClient:
     ):
         """
         Initialize the Allora blockchain client.
-        
+
         Args:
             config: Network configuration. If None, uses testnet config.
             private_key: Hex-encoded private key for signing transactions.
@@ -140,7 +140,7 @@ class AlloraRPCClient:
                 tendermint_v1beta1.ServiceStub(self.grpc_client),
             )
             tx_query = cast(rest.CosmosTxV1Beta1ServiceLike, cosmos_tx_v1beta1.ServiceStub(self.grpc_client))
-            emissions_query = cast(rest.EmissionsV9QueryServiceLike, emissions_v9.QueryServiceStub(self.grpc_client))
+            emissions_query = cast(rest.EmissionsV10QueryServiceLike, emissions_v10.QueryServiceStub(self.grpc_client))
             mint_query = cast(rest.MintV5QueryServiceLike, mint_v5.QueryServiceStub(self.grpc_client))
             feemarket_query = cast(rest.FeemarketFeemarketV1QueryLike, feemarket_v1.QueryStub(self.grpc_client))
             staking_query = cosmos_staking_v1beta1.QueryStub(self.grpc_client)
@@ -150,7 +150,7 @@ class AlloraRPCClient:
             bank_query: rest.CosmosBankV1Beta1QueryLike = rest.CosmosBankV1Beta1RestQueryClient(parsed_url.rest_url)
             tendermint_query: rest.CosmosBaseTendermintV1Beta1ServiceLike = rest.CosmosBaseTendermintV1Beta1RestServiceClient(parsed_url.rest_url)
             tx_query: rest.CosmosTxV1Beta1ServiceLike = rest.CosmosTxV1Beta1RestServiceClient(parsed_url.rest_url)
-            emissions_query: rest.EmissionsV9QueryServiceLike = rest.EmissionsV9RestQueryServiceClient(parsed_url.rest_url)
+            emissions_query: rest.EmissionsV10QueryServiceLike = rest.EmissionsV10RestQueryServiceClient(parsed_url.rest_url)
             mint_query: rest.MintV5QueryServiceLike = rest.MintV5RestQueryServiceClient(parsed_url.rest_url)
             feemarket_query: rest.FeemarketFeemarketV1QueryLike = rest.FeemarketFeemarketV1RestQueryClient(parsed_url.rest_url)
             staking_query = None
@@ -177,9 +177,9 @@ class AlloraRPCClient:
 
         if self.network.websocket_url is not None:
             self.events = AlloraWebsocketSubscriber(self.network.websocket_url)
-        
+
         logger.debug(f"Initialized Allora client for {self.network.chain_id}")
-    
+
 
     def _initialize_wallet(self, wallet: Optional[AlloraWalletConfig]):
         """Initialize wallet from private key or mnemonic."""
@@ -205,7 +205,7 @@ class AlloraRPCClient:
         except Exception as e:
             logger.error(f"Failed to initialize wallet: {e}")
             raise ValueError(f"Invalid wallet credentials: {e}")
-    
+
 
     async def raise_for_chain_id_mismatch(self):
         chain_id = await self.chain_id()
@@ -224,14 +224,14 @@ class AlloraRPCClient:
         """Get the wallet address if wallet is initialized."""
         return str(self.wallet.address()) if self.wallet else None
 
-    
+
     @property
     def public_key(self) -> Optional[str]:
         """Get the wallet public key if wallet is initialized."""
         if self.wallet:
             return self.wallet.public_key().public_key_hex
         return None
-    
+
 
     async def close(self):
         """Close client and cleanup resources."""

--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 from typing import Dict, List, Optional
 from allora_sdk.rpc_client.protos.emissions.v3 import Nonce, ReputerRequestNonce
-from allora_sdk.rpc_client.protos.emissions.v9 import (
+from allora_sdk.rpc_client.protos.emissions.v10 import (
     AddStakeRequest,
     BulkAddToTopicReputerWhitelistRequest,
     BulkAddToTopicWorkerWhitelistRequest,
@@ -14,21 +14,24 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     InputWorkerDataBundle,
     InsertWorkerPayloadRequest,
     InsertReputerPayloadRequest,
-    InputReputerValueBundle,
-    InputValueBundle,
     InputForecastElement,
     InputForecast,
     RegisterRequest,
+    InputLabeledValue,
+)
+from allora_sdk.rpc_client.protos.emissions.v9 import (
+    InputReputerValueBundle,
+    InputValueBundle,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxManager, PendingTx, WalletNotConfiguredError
-from allora_sdk.rpc_client.rest import EmissionsV9QueryServiceLike
+from allora_sdk.rpc_client.rest import EmissionsV10QueryServiceLike
 from allora_sdk.rpc_client.dec_canonical import canonicalize_dec
 
 logger = logging.getLogger("allora_sdk")
 
 
 class EmissionsClient:
-    def __init__(self, query_client: EmissionsV9QueryServiceLike, tx_manager: TxManager | None = None):
+    def __init__(self, query_client: EmissionsV10QueryServiceLike, tx_manager: TxManager | None = None):
         self.query = query_client
         if tx_manager is not None:
             self.tx = EmissionsTxs(txs=tx_manager)
@@ -67,7 +70,7 @@ class EmissionsTxs:
         )
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.RegisterRequest",
+            type_url="/emissions.v10.RegisterRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )
@@ -75,7 +78,7 @@ class EmissionsTxs:
     async def insert_worker_payload(
         self,
         topic_id: int,
-        inference_value: Optional[str],
+        inference_value: Optional[list[InputLabeledValue]],
         nonce: int,
         forecast_elements: Optional[List[Dict[str, str]]] = None,
         extra_data: Optional[bytes] = None,
@@ -88,7 +91,7 @@ class EmissionsTxs:
 
         Args:
             topic_id: The topic ID to submit inference for
-            inference_value: Optional inference value as a string. Set to None for forecast-only payloads.
+            inference_value: Optional inference value. Set to None for forecast-only payloads.
             nonce: Block height/nonce for the inference
             forecast_elements: Optional list of forecast elements
                               [{"inferer": "address", "value": "prediction"}]
@@ -114,7 +117,8 @@ class EmissionsTxs:
                 topic_id=topic_id,
                 block_height=nonce,
                 inferer=worker_address,
-                value=canonicalize_dec(inference_value),
+                value="0",
+                values=inference_value,
                 extra_data=extra_data or b"",
                 proof=proof or "",
             )
@@ -165,7 +169,7 @@ class EmissionsTxs:
         logger.debug(f"   Payload details: nonce={nonce}, forecaster={worker_address}")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.InsertWorkerPayloadRequest",
+            type_url="/emissions.v10.InsertWorkerPayloadRequest",
             msgs=[payload_request],
             fee_tier=fee_tier,
             account_seq=account_seq,
@@ -201,7 +205,7 @@ class EmissionsTxs:
         )
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.DelegateStakeRequest",
+            type_url="/emissions.v10.DelegateStakeRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )
@@ -237,7 +241,7 @@ class EmissionsTxs:
         logger.debug(f"Adding stake of {amount} uallo to topic {topic_id}")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.AddStakeRequest",
+            type_url="/emissions.v10.AddStakeRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )
@@ -291,7 +295,7 @@ class EmissionsTxs:
         logger.debug(f"Submitting reputer payload for topic {topic_id}")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.InsertReputerPayloadRequest",
+            type_url="/emissions.v10.InsertReputerPayloadRequest",
             msgs=[payload_request],
             fee_tier=fee_tier,
             account_seq=account_seq,
@@ -367,7 +371,7 @@ class EmissionsTxs:
         logger.debug(f"Creating new topic with metadata: {metadata}")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.CreateNewTopicRequest",
+            type_url="/emissions.v10.CreateNewTopicRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )
@@ -403,7 +407,7 @@ class EmissionsTxs:
         logger.debug(f"Funding topic {topic_id} with {amount} uallo")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.FundTopicRequest",
+            type_url="/emissions.v10.FundTopicRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )
@@ -439,7 +443,7 @@ class EmissionsTxs:
         logger.debug(f"Adding {len(addresses)} addresses to topic {topic_id} worker whitelist")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.BulkAddToTopicWorkerWhitelistRequest",
+            type_url="/emissions.v10.BulkAddToTopicWorkerWhitelistRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )
@@ -475,7 +479,7 @@ class EmissionsTxs:
         logger.debug(f"Adding {len(addresses)} addresses to topic {topic_id} reputer whitelist")
 
         return await self._txs.submit_transaction(
-            type_url="/emissions.v9.BulkAddToTopicReputerWhitelistRequest",
+            type_url="/emissions.v10.BulkAddToTopicReputerWhitelistRequest",
             msgs=[msg],
             fee_tier=fee_tier,
         )

--- a/src/allora_sdk/rpc_client/client_websocket_events.py
+++ b/src/allora_sdk/rpc_client/client_websocket_events.py
@@ -797,7 +797,7 @@ class AlloraWebsocketSubscriber:
         Subscribe to specific events within NewBlockEvents.
         
         Args:
-            event_name: The specific event type to filter for (e.g., "emissions.v9.EventEMAScoresSet")
+            event_name: The specific event type to filter for (e.g., "emissions.v10.EventEMAScoresSet")
             event_attribute_conditions: List of attribute conditions to apply
             callback: Function to call for each matching event (event, block_height)
             subscription_id: Optional custom subscription ID
@@ -866,7 +866,7 @@ class AlloraWebsocketSubscriber:
             self._subscription_id_counter += 1
             subscription_id = f"typed_block_events_{self._subscription_id_counter}"
         
-        # Extract event name from class (e.g., EventScoresSet -> emissions.v9.EventScoresSet)
+        # Extract event name from class (e.g., EventScoresSet -> emissions.v10.EventScoresSet)
         event_name = self._get_event_type_from_class(event_class)
         if not event_name:
             logger.error(f"❌ Could not determine event type for class {event_class.__name__}")

--- a/src/allora_sdk/rpc_client/event_utils.py
+++ b/src/allora_sdk/rpc_client/event_utils.py
@@ -94,7 +94,7 @@ class EventMarshaler:
 
     e.g.
     {
-        "type": "emissions.v9.EventReputerSubmissionWindowOpened",
+        "type": "emissions.v10.EventReputerSubmissionWindowOpened",
         "attributes": [
             {"key": "topic_id", "value": "42"},
             {"key": "nonce", "value": "12893851"},
@@ -105,7 +105,7 @@ class EventMarshaler:
 
     becomes
 
-    emissions.v9.EventReputerSubmissionWindowOpened(
+    emissions.v10.EventReputerSubmissionWindowOpened(
         topic_id=42,
         nonce=12893851,
         window_start_height=123456,

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -137,11 +137,11 @@ class TxManager:
         self._parent_tx_id_lock = asyncio.Lock()
 
         self._default_gas_limits = {
-            "/emissions.v9.InsertWorkerPayloadRequest": 250000,
-            "/emissions.v9.CreateNewTopicRequest": 300000,
-            "/emissions.v9.FundTopicRequest": 150000,
-            "/emissions.v9.BulkAddToTopicWorkerWhitelistRequest": 200000,
-            "/emissions.v9.BulkAddToTopicReputerWhitelistRequest": 200000,
+            "/emissions.v10.InsertWorkerPayloadRequest": 250000,
+            "/emissions.v10.CreateNewTopicRequest": 300000,
+            "/emissions.v10.FundTopicRequest": 150000,
+            "/emissions.v10.BulkAddToTopicWorkerWhitelistRequest": 200000,
+            "/emissions.v10.BulkAddToTopicReputerWhitelistRequest": 200000,
             "/cosmos.bank.v1beta1.MsgSend": 250000,
             "/cosmos.staking.v1beta1.MsgDelegate": 100000,
             "/cosmos.staking.v1beta1.MsgUndelegate": 100000,

--- a/src/allora_sdk/tools/export_txs_to_csv.py
+++ b/src/allora_sdk/tools/export_txs_to_csv.py
@@ -12,7 +12,7 @@ import argparse
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.config import AlloraNetworkConfig
 from allora_sdk.rpc_client.protos.cosmos.tx.v1beta1 import GetTxsEventRequest, GetTxsEventResponse, OrderBy
-from allora_sdk.rpc_client.protos.emissions.v9 import InsertWorkerPayloadRequest
+from allora_sdk.rpc_client.protos.emissions.v10 import InsertWorkerPayloadRequest
 
 
 def main():
@@ -101,7 +101,7 @@ def filter_and_extract_data(data: GetTxsEventResponse):
         if tx.body is None:
             continue
 
-        target_suffix = "emissions.v9.InsertWorkerPayloadRequest"
+        target_suffix = "emissions.v10.InsertWorkerPayloadRequest"
         qualifying_messages = [ msg for msg in tx.body.messages if msg.type_url.endswith(target_suffix) ]
 
         for m in qualifying_messages:

--- a/src/allora_sdk/worker/autostake.py
+++ b/src/allora_sdk/worker/autostake.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, Iterable
 
 from allora_sdk.rpc_client.protos.cosmos.bank.v1beta1 import QueryBalanceRequest
-from allora_sdk.rpc_client.protos.emissions.v9 import (
+from allora_sdk.rpc_client.protos.emissions.v10 import (
     EventRewardsSettled,
     IsReputerRegisteredInTopicIdRequest,
 )

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -9,6 +9,7 @@ from allora_sdk.rpc_client.protos.emissions.v10 import (
     GetUnfulfilledWorkerNoncesRequest,
     IsWorkerRegisteredInTopicIdRequest,
 )
+from allora_sdk.rpc_client.dec_canonical import canonicalize_dec
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
 from allora_sdk.worker.context import RunContext
 from allora_sdk.worker.types import AlreadySubmittedError, TRunFn, UseCase, WorkerResult
@@ -139,15 +140,10 @@ class Forecaster:
                 logger.warning("Empty forecasts dict provided, skipping submission")
                 return Exception("Empty forecasts dict")
 
-            # Coerce/validate to stable {str: float} and keep a canonical ordering for signing.
-            forecasts: dict[str, float] = {}
-            for addr, pred in forecasts_raw.items():
-                forecasts[str(addr)] = float(pred)
-
             # Convert to forecast_elements format: [{"inferer": addr, "value": str}, ...]
             forecast_elements = [
-                {"inferer": addr, "value": str(pred)}
-                for addr, pred in sorted(forecasts.items(), key=lambda kv: kv[0])
+                {"inferer": addr, "value": canonicalize_dec(pred)}
+                for addr, pred in sorted(forecasts_raw.items(), key=lambda kv: kv[0])
             ]
 
             pending = await self.client.emissions.tx.insert_worker_payload(

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -156,7 +156,7 @@ class Forecaster:
             )
             resp = await pending.wait()
 
-            return WorkerResult(submission=forecasts, tx_result=resp)
+            return WorkerResult(submission=forecasts_raw, tx_result=resp)
 
         except TxError as err:
             already_submitted = False

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict
 from cosmpy.aerial.wallet import LocalWallet
 from allora_sdk.rpc_client.client import AlloraRPCClient
-from allora_sdk.rpc_client.protos.emissions.v9 import (
+from allora_sdk.rpc_client.protos.emissions.v10 import (
     CanSubmitWorkerPayloadRequest,
     EventWorkerSubmissionWindowOpened,
     EventRewardsSettled,

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -16,6 +16,7 @@ from allora_sdk.rpc_client.protos.emissions.v10 import (
     IsWorkerRegisteredInTopicIdRequest,
     InputLabeledValue,
 )
+from allora_sdk.rpc_client.dec_canonical import canonicalize_dec
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
 from allora_sdk.worker.context import RunContext
 from allora_sdk.worker.types import AlreadySubmittedError, StopQueue, TRunFn, UseCase, WorkerResult
@@ -192,9 +193,9 @@ class Inferer:
                 logger.debug(f"Could not convert prediction to float for sanity check: {prediction}")
 
         if isinstance(prediction, dict):
-            prediction_dict = [InputLabeledValue(label=label, value=str(value)) for (label, value) in prediction.items()]
+            prediction_dict = [InputLabeledValue(label=label, value=canonicalize_dec(value)) for (label, value) in prediction.items()]
         else:
-            prediction_dict = [InputLabeledValue(label='y', value=str(prediction))]
+            prediction_dict = [InputLabeledValue(label='y', value=canonicalize_dec(prediction))]
 
         try:
             pending = await self.client.emissions.tx.insert_worker_payload(

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -7,13 +7,14 @@ from typing import Union
 from cosmpy.aerial.wallet import LocalWallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
-from allora_sdk.rpc_client.protos.emissions.v9 import (
+from allora_sdk.rpc_client.protos.emissions.v10 import (
     CanSubmitWorkerPayloadRequest,
     EventWorkerSubmissionWindowOpened,
     EventRewardsSettled,
     GetLatestNetworkInferencesRequest,
     GetUnfulfilledWorkerNoncesRequest,
     IsWorkerRegisteredInTopicIdRequest,
+    InputLabeledValue,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
 from allora_sdk.worker.context import RunContext
@@ -45,7 +46,8 @@ class SanityCheckConfig:
             raise ValueError("throttle_interval_seconds must be >= 0")
 
 
-TInfererRunFnResult = Union[str, float, Decimal]
+TInfererRunFnResultPrimitive = Union[str, float, Decimal]
+TInfererRunFnResult = TInfererRunFnResultPrimitive | dict[str, TInfererRunFnResultPrimitive]
 TInfererRunFn = TRunFn[TInfererRunFnResult]
 
 
@@ -182,16 +184,24 @@ class Inferer:
             return err
 
         # Sanity check prediction against network consensus (throttled; see SanityCheckConfig)
-        if self.sanity_check.enabled:
+        # We currently skip the sanity check for multi-output topics
+        if self.sanity_check.enabled and not isinstance(prediction, dict):
             try:
                 await self._sanity_check_submission(float(prediction))
             except (ValueError, TypeError):
                 logger.debug(f"Could not convert prediction to float for sanity check: {prediction}")
 
+        if isinstance(prediction, TInfererRunFnResultPrimitive):
+            prediction_dict = [InputLabeledValue(label='y', value=str(prediction))]
+        elif isinstance(prediction, TInfererRunFnResult):
+            prediction_dict = [InputLabeledValue(label=label, value=str(value)) for (label, value) in prediction.items()]
+        else:
+            raise ValueError(f'Prediction has type {type(prediction)} which is not supported.')
+
         try:
             pending = await self.client.emissions.tx.insert_worker_payload(
                 topic_id=self.topic_id,
-                inference_value=str(prediction),
+                inference_value=prediction_dict,
                 nonce=nonce,
                 fee_tier=self.fee_tier,
                 account_seq=account_seq,
@@ -282,9 +292,11 @@ class Inferer:
                     return
 
                 inferer_values = []
-                for inferer in response.network_inferences.inferer_values:
+                for wi in response.network_inferences.inferer_values:
+                    if not wi.values:
+                        continue
                     try:
-                        inferer_values.append(float(inferer.value))
+                        inferer_values.append(float(wi.values[0].value))
                     except (ValueError, TypeError):
                         continue
 

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -191,12 +191,10 @@ class Inferer:
             except (ValueError, TypeError):
                 logger.debug(f"Could not convert prediction to float for sanity check: {prediction}")
 
-        if isinstance(prediction, TInfererRunFnResultPrimitive):
-            prediction_dict = [InputLabeledValue(label='y', value=str(prediction))]
-        elif isinstance(prediction, TInfererRunFnResult):
+        if isinstance(prediction, dict):
             prediction_dict = [InputLabeledValue(label=label, value=str(value)) for (label, value) in prediction.items()]
         else:
-            raise ValueError(f'Prediction has type {type(prediction)} which is not supported.')
+            prediction_dict = [InputLabeledValue(label='y', value=str(prediction))]
 
         try:
             pending = await self.client.emissions.tx.insert_worker_payload(

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -5,19 +5,23 @@ from typing import List, Optional, Union, Callable, Awaitable
 from cosmpy.aerial.wallet import LocalWallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
-from allora_sdk.rpc_client.protos.emissions.v3 import Nonce, ReputerRequestNonce, ValueBundle
-from allora_sdk.rpc_client.protos.emissions.v9 import (
+from allora_sdk.rpc_client.protos.emissions.v3 import Nonce, ReputerRequestNonce
+from allora_sdk.rpc_client.protos.emissions.v10 import (
     CanSubmitReputerPayloadRequest,
     EventReputerSubmissionWindowOpened,
     GetNetworkInferencesAtBlockRequest,
     GetStakeFromReputerInTopicInSelfRequest,
     GetTopicRequest,
     GetUnfulfilledReputerNoncesRequest,
+    IsReputerRegisteredInTopicIdRequest,
+    NetworkInferenceBundle,
+    LabeledValue,
+)
+from allora_sdk.rpc_client.protos.emissions.v9 import (
     InputOneOutInfererForecasterValues,
     InputValueBundle,
     InputWithheldWorkerAttributedValue,
     InputWorkerAttributedValue,
-    IsReputerRegisteredInTopicIdRequest,
 )
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError
 from allora_sdk.rpc_client.dec_canonical import canonicalize_dec
@@ -28,8 +32,8 @@ from allora_sdk.worker.utils import resolve_maybe_awaitable
 logger = logging.getLogger("allora_sdk")
 
 ReputerFnResult = Union[str, float, Decimal]
-ReputerFnAsync = Callable[[RunContext, float], Awaitable[ReputerFnResult]]
-ReputerFnSync = Callable[[RunContext, float], ReputerFnResult]
+ReputerFnAsync = Callable[[RunContext, dict[str, float]], Awaitable[ReputerFnResult]]
+ReputerFnSync = Callable[[RunContext, dict[str, float]], ReputerFnResult]
 ReputerFn = ReputerFnSync | ReputerFnAsync
 
 class Reputer:
@@ -201,30 +205,21 @@ class Reputer:
 
         return result
 
-    async def _compute_loss_bundle(self, value_bundle: ValueBundle) -> InputValueBundle:
+    async def _compute_loss_bundle(self, network_inference: NetworkInferenceBundle) -> InputValueBundle:
         """
         Compute loss bundle from ground truth and network inferences.
 
         Computes losses for combined, naive, inferer, forecaster, one-out, and one-in values.
         """
 
-        async def compute_loss(value_str: str) -> str:
+        async def compute_loss(values: list[LabeledValue]) -> str:
             try:
-                predicted = float(value_str)
+                predicted = {v.label_name: float(v.value) for v in values}
             except (ValueError, TypeError) as err:
-                raise ValueError(f"invalid numeric value for loss computation: '{value_str}'") from err
+                raise ValueError(f"invalid numeric value for loss computation: {values}") from err
 
-            if not math.isfinite(predicted):
-                raise ValueError(
-                    f"predicted must be finite (got non-finite value: {predicted})"
-                )
-
-            if self.reputer_fn is None:
-                raise ValueError("no reputer_fn configured")
-
-            nonce = value_bundle.reputer_request_nonce.reputer_nonce.block_height
             run_context = RunContext(
-                nonce = nonce,
+                nonce = network_inference.nonce,
                 client = self.client,
                 topic_id = self.topic_id
             )
@@ -232,91 +227,47 @@ class Reputer:
             loss = await resolve_maybe_awaitable(self.reputer_fn, run_context, predicted)
             return canonicalize_dec(loss)
 
-        # Compute combined and naive losses
-        combined_loss = await compute_loss(value_bundle.combined_value) if value_bundle.combined_value else "0"
-        naive_loss = await compute_loss(value_bundle.naive_value) if value_bundle.naive_value else "0"
+        if self.reputer_fn is None:
+            raise ValueError("no reputer_fn configured")
 
-        # Compute inferer losses
-        inferer_values: List[InputWorkerAttributedValue] = []
-        if value_bundle.inferer_values:
-            for iv in value_bundle.inferer_values:
-                inferer_values.append(InputWorkerAttributedValue(
-                    worker=iv.worker,
-                    value=await compute_loss(iv.value) if iv.value else "0",
-                ))
-
-        # Compute forecaster losses
-        forecaster_values: List[InputWorkerAttributedValue] = []
-        if value_bundle.forecaster_values:
-            for fv in value_bundle.forecaster_values:
-                forecaster_values.append(InputWorkerAttributedValue(
-                    worker=fv.worker,
-                    value=await compute_loss(fv.value) if fv.value else "0",
-                ))
-
-        # Compute one-out inferer losses
-        one_out_inferer_values: List[InputWithheldWorkerAttributedValue] = []
-        if value_bundle.one_out_inferer_values:
-            for ooi in value_bundle.one_out_inferer_values:
-                one_out_inferer_values.append(InputWithheldWorkerAttributedValue(
-                    worker=ooi.worker,
-                    value=await compute_loss(ooi.value) if ooi.value else "0",
-                ))
-
-        # Compute one-out forecaster losses
-        one_out_forecaster_values: List[InputWithheldWorkerAttributedValue] = []
-        if value_bundle.one_out_forecaster_values:
-            for oof in value_bundle.one_out_forecaster_values:
-                one_out_forecaster_values.append(InputWithheldWorkerAttributedValue(
-                    worker=oof.worker,
-                    value=await compute_loss(oof.value) if oof.value else "0",
-                ))
-
-        # Compute one-in forecaster losses
-        one_in_forecaster_values: List[InputWorkerAttributedValue] = []
-        if value_bundle.one_in_forecaster_values:
-            for oif in value_bundle.one_in_forecaster_values:
-                one_in_forecaster_values.append(InputWorkerAttributedValue(
-                    worker=oif.worker,
-                    value=await compute_loss(oif.value) if oif.value else "0",
-                ))
+        combined_loss = await compute_loss(network_inference.combined_value)
+        naive_loss = await compute_loss(network_inference.naive_value)
+        inferer_losses = [InputWorkerAttributedValue(worker=x.worker, value=await compute_loss(x.values)) for x in network_inference.inferer_values]
+        forecaster_losses = [InputWorkerAttributedValue(worker=x.worker, value=await compute_loss(x.values)) for x in network_inference.forecaster_values]
+        one_out_inferer_losses = [InputWithheldWorkerAttributedValue(worker=x.withheld_inferer, value = await compute_loss(x.combined_inference)) for x in network_inference.one_out_inferer_values]
+        one_out_forecaster_losses = [InputWithheldWorkerAttributedValue(worker=x.withheld_forecaster, value = await compute_loss(x.combined_inference)) for x in network_inference.one_out_forecaster_values]
+        one_in_forecaster_losses = [InputWorkerAttributedValue(worker=x.forecaster, value = await compute_loss(x.combined_inference)) for x in network_inference.one_in_forecaster_values]
 
         # Compute one-out inferer-forecaster losses
-        one_out_inferer_forecaster_values: List[InputOneOutInfererForecasterValues] = []
-        if value_bundle.one_out_inferer_forecaster_values:
-            for ooif in value_bundle.one_out_inferer_forecaster_values:
-                one_out_losses: List[InputWithheldWorkerAttributedValue] = []
-                if ooif.one_out_inferer_values:
-                    for withheld in ooif.one_out_inferer_values:
-                        one_out_losses.append(
-                            InputWithheldWorkerAttributedValue(
-                                worker=withheld.worker,
-                                value=await compute_loss(withheld.value)
-                                if withheld.value
-                                else "0",
-                            )
-                        )
+        # v10 flattens these: each OneOutInfererForecasterValue has .forecaster, .withheld_inferer, .combined_inference
+        # Group by forecaster to produce InputOneOutInfererForecasterValues (which expects nested structure)
+        ooifs: dict[str, dict[str, str]] = {}
+        for ooif in network_inference.one_out_inferer_forecaster_values:
+            if not ooif.forecaster in ooifs:
+                oofs[ooif.forecaster] = {}
+            ooifs[ooif.forecaster][ooif.withheld_inferer] = await compute_loss(ooif.combined_inference)
 
-                one_out_inferer_forecaster_values.append(
-                    InputOneOutInfererForecasterValues(
-                        forecaster=ooif.forecaster,
-                        one_out_inferer_values=one_out_losses,
-                    )
-                )
+        one_out_inferer_forecaster_losses = [
+            InputOneOutInfererForecasterValues(
+                forecaster=f,
+                one_out_inferer_values=InputWithheldWorkerAttributedValue(
+                    worker=i,
+                    value=v,
+                ))
+            for (f, x) in ooifs for (i, v) in x
+        ]
 
-        result = InputValueBundle(
+        return InputValueBundle(
             topic_id=self.topic_id,
             combined_value=combined_loss,
             naive_value=naive_loss,
-            inferer_values=inferer_values,
-            forecaster_values=forecaster_values,
-            one_out_inferer_values=one_out_inferer_values,
-            one_out_forecaster_values=one_out_forecaster_values,
-            one_in_forecaster_values=one_in_forecaster_values,
-            one_out_inferer_forecaster_values=one_out_inferer_forecaster_values,
+            inferer_values=inferer_losses,
+            forecaster_values=forecaster_losses,
+            one_out_inferer_values=one_out_inferer_losses,
+            one_out_forecaster_values=one_out_forecaster_losses,
+            one_in_forecaster_values=one_in_forecaster_losses,
+            one_out_inferer_forecaster_values=one_out_inferer_forecaster_losses,
         )
-
-        return result
 
 
     async def _maybe_stake(self):

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -244,7 +244,7 @@ class Reputer:
         ooifs: dict[str, dict[str, str]] = {}
         for ooif in network_inference.one_out_inferer_forecaster_values:
             if not ooif.forecaster in ooifs:
-                oofs[ooif.forecaster] = {}
+                ooifs[ooif.forecaster] = {}
             ooifs[ooif.forecaster][ooif.withheld_inferer] = await compute_loss(ooif.combined_inference)
 
         one_out_inferer_forecaster_losses = [
@@ -254,7 +254,7 @@ class Reputer:
                     worker=i,
                     value=v,
                 ))
-            for (f, x) in ooifs for (i, v) in x
+            for (f, x) in ooifs.items() for (i, v) in x.items()
         ]
 
         return InputValueBundle(

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -250,11 +250,12 @@ class Reputer:
         one_out_inferer_forecaster_losses = [
             InputOneOutInfererForecasterValues(
                 forecaster=f,
-                one_out_inferer_values=InputWithheldWorkerAttributedValue(
-                    worker=i,
-                    value=v,
-                ))
-            for (f, x) in ooifs.items() for (i, v) in x.items()
+                one_out_inferer_values=[
+                    InputWithheldWorkerAttributedValue(worker=i, value=v)
+                    for (i, v) in inferers.items()
+                ],
+            )
+            for (f, inferers) in ooifs.items()
         ]
 
         return InputValueBundle(

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -10,8 +10,7 @@ from cosmpy.mnemonic import PrivateKey, generate_mnemonic
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
 from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetBlockByHeightRequest
-from allora_sdk.rpc_client.protos.emissions.v9 import GetNetworkInferencesAtBlockRequest
-from allora_sdk.rpc_client.protos.emissions.v3 import ValueBundle
+from allora_sdk.rpc_client.protos.emissions.v10 import GetNetworkInferencesAtBlockRequest, NetworkInferenceBundle, LabeledValue
 from .context import RunContext
 
 logger = logging.getLogger("allora_sdk")
@@ -80,7 +79,7 @@ async def get_block_time(client: AlloraRPCClient, height: int) -> datetime:
     block_time = response.sdk_block.header.time
     return block_time
 
-async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: int) -> ValueBundle | None:
+async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: int) -> NetworkInferenceBundle | None:
     """Fetch the network inference bundle for a topic at a specific block height.
 
     Args:
@@ -99,7 +98,8 @@ async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: i
     return network_inferences_resp.network_inferences
 
 Truth = TypeVar('Truth')
-def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[Truth, float], float], log_loss: bool = True) -> Callable[[RunContext, float], Awaitable[float]]:
+Inference = float | dict[str, float]
+def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[Truth, Inference], float], log_loss: bool = True) -> Callable[[RunContext, Inference], Awaitable[float]]:
     """Build a reputer scoring function from separate ground-truth and loss components.
 
     Returns a function that can be passed to `AlloraWorker.reputer()`. The ground truth function
@@ -121,7 +121,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
     # Ground truth is cached for the current topic/nonce bundle only.
     gt_cache: tuple[tuple[int, int], Truth] | None = None
 
-    async def rep_func(context: RunContext, inference: float) -> float:
+    async def rep_func(context: RunContext, inference: dict[str, float]) -> float:
         nonlocal gt_cache
 
         cache_key = (context.topic_id, context.nonce)
@@ -133,7 +133,14 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
 
             logger.info(f'📐 Ground truth for topic {context.topic_id} at nonce {context.nonce}: {gt}')
 
-        loss = loss_fn(gt, inference)
+        if len(inference) != 1 or 'y' not in inference:
+            raise Error('Expected scalar, got vector valued network inference')
+
+        if multi_output:
+            loss = loss_fn(gt, inference)
+        else:
+            # scalar-valued topics are represented by a single element dict with the key "y"
+            loss = loss_fn(gt, inference['y'])
 
         if log_loss:
             loss = math.log10(loss + 1e-100)

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -133,12 +133,12 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
 
             logger.info(f'📐 Ground truth for topic {context.topic_id} at nonce {context.nonce}: {gt}')
 
-        if len(inference) != 1 or 'y' not in inference:
-            raise Error('Expected scalar, got vector valued network inference')
-
         if multi_output:
             loss = loss_fn(gt, inference)
         else:
+            if len(inference) != 1 or 'y' not in inference:
+                raise ValueError('Expected scalar, got vector valued network inference')
+
             # scalar-valued topics are represented by a single element dict with the key "y"
             loss = loss_fn(gt, inference['y'])
 

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -8,9 +8,9 @@ from typing import Awaitable, Callable, ParamSpec, TypeVar, Union, cast
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.mnemonic import PrivateKey, generate_mnemonic
 from allora_sdk.rpc_client.client import AlloraRPCClient
-from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
+from allora_sdk.rpc_client.config import AlloraWalletConfig
 from allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 import GetBlockByHeightRequest
-from allora_sdk.rpc_client.protos.emissions.v10 import GetNetworkInferencesAtBlockRequest, NetworkInferenceBundle, LabeledValue
+from allora_sdk.rpc_client.protos.emissions.v10 import GetNetworkInferencesAtBlockRequest, NetworkInferenceBundle
 from .context import RunContext
 
 logger = logging.getLogger("allora_sdk")
@@ -99,7 +99,7 @@ async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: i
 
 Truth = TypeVar('Truth')
 Inference = float | dict[str, float]
-def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[Truth, Inference], float], log_loss: bool = True) -> Callable[[RunContext, Inference], Awaitable[float]]:
+def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[Truth, Inference], float], log_loss: bool = True, multi_output: bool = False) -> Callable[[RunContext, dict[str, float]], Awaitable[float]]:
     """Build a reputer scoring function from separate ground-truth and loss components.
 
     Returns a function that can be passed to `AlloraWorker.reputer()`. The ground truth function
@@ -114,7 +114,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
         gt_fn: Async function that fetches the ground-truth value. The ground truth can be any type.
         loss_fn: Function that computes a scalar loss given the ground truth and an inference.
         log_loss: If true, take log10 of each loss value before submitting (the chain expects log losses)
-        multi_output: If true, passes inference as to callback `dict[str, float]` instead of unpacking.
+        multi_output: If true, passes inference to callback as `dict[str, float]` instead of unpacking to `float`.
 
     Returns:
         An async function ``(context, inference) -> float`` suitable for use as a reputer function.

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -114,6 +114,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
         gt_fn: Async function that fetches the ground-truth value. The ground truth can be any type.
         loss_fn: Function that computes a scalar loss given the ground truth and an inference.
         log_loss: If true, take log10 of each loss value before submitting (the chain expects log losses)
+        multi_output: If true, passes inference as to callback `dict[str, float]` instead of unpacking.
 
     Returns:
         An async function ``(context, inference) -> float`` suitable for use as a reputer function.

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -19,19 +19,19 @@ from allora_sdk.rpc_client.protos.cosmos.auth.v1beta1 import QueryAccountInfoReq
 from allora_sdk.rpc_client.protos.cosmos.bank.v1beta1 import QueryBalanceRequest
 import async_timeout
 
-from allora_sdk.rpc_client.protos.emissions.v9 import GetTopicRequest
-from allora_sdk.rpc_client.client import AlloraRPCClient
-from allora_sdk.rpc_client.client_websocket_events import EventAttributeCondition
-from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
-from allora_sdk.rpc_client.tx_manager import FeeTier, TxError, TxTimeoutError
-from allora_sdk.rpc_client.protos.emissions.v9 import (
+from allora_sdk.rpc_client.protos.emissions.v10 import (
+    GetTopicRequest,
     EventReputerSubmissionWindowClosed,
     EventReputerSubmissionWindowOpened,
     EventRewardsSettled,
     EventWorkerSubmissionWindowOpened,
     EventWorkerSubmissionWindowClosed,
-    InputValueBundle,
 )
+from allora_sdk.rpc_client.protos.emissions.v9 import InputValueBundle
+from allora_sdk.rpc_client.client import AlloraRPCClient
+from allora_sdk.rpc_client.client_websocket_events import EventAttributeCondition
+from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
+from allora_sdk.rpc_client.tx_manager import FeeTier, TxError, TxTimeoutError
 from allora_sdk.utils import Context, TimestampOrderedSet, format_allo_from_uallo
 from allora_sdk.logging_config import setup_sdk_logging
 from allora_sdk.worker.forecaster import Forecaster, TForecasterRunFn, TForecasterRunFnResult
@@ -685,7 +685,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         nonces = await self.use_case.get_unfulfilled_nonces()
         new_nonces = { n for n in nonces if n not in self.submitted_nonces }
 
-        if nonce is not None:
+        if nonce is not None and nonce not in self.submitted_nonces:
             new_nonces.add(nonce)
 
         nonces_str     = f"{nonces}" if len(nonces) > 0 else "-"

--- a/tests/fixtures/new_block_events.json
+++ b/tests/fixtures/new_block_events.json
@@ -3,7 +3,7 @@
     "id": "typed_block_events_1",
     "result":
     {
-        "query": "tm.event='NewBlockEvents' AND emissions.v9.EventWorkerLastCommitSet.topic_id CONTAINS '13'",
+        "query": "tm.event='NewBlockEvents' AND emissions.v10.EventWorkerLastCommitSet.topic_id CONTAINS '13'",
         "data":
         {
             "type": "tendermint/event/NewBlockEvents",
@@ -2669,7 +2669,7 @@
                         ]
                     },
                     {
-                        "type": "emissions.v9.EventTopicRewardsSet",
+                        "type": "emissions.v10.EventTopicRewardsSet",
                         "attributes":
                         [
                             {
@@ -2690,7 +2690,7 @@
                         ]
                     },
                     {
-                        "type": "emissions.v9.EventNetworkInferences",
+                        "type": "emissions.v10.EventNetworkInferences",
                         "attributes":
                         [
                             {
@@ -2716,7 +2716,7 @@
                         ]
                     },
                     {
-                        "type": "emissions.v9.EventWorkerLastCommitSet",
+                        "type": "emissions.v10.EventWorkerLastCommitSet",
                         "attributes":
                         [
                             {
@@ -2768,15 +2768,15 @@
             [
                 "\"5100967\""
             ],
-            "emissions.v9.EventTopicRewardsSet.rewards":
+            "emissions.v10.EventTopicRewardsSet.rewards":
             [
                 "[\"0\"]"
             ],
-            "emissions.v9.EventTopicRewardsSet.mode":
+            "emissions.v10.EventTopicRewardsSet.mode":
             [
                 "EndBlock"
             ],
-            "emissions.v9.EventNetworkInferences.value_bundle":
+            "emissions.v10.EventNetworkInferences.value_bundle":
             [
                 "{\"topic_id\":\"13\",\"reputer_request_nonce\":{\"reputer_nonce\":{\"block_height\":\"5100955\"}},\"reputer\":\"allo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqas6usy\",\"extra_data\":null,\"combined_value\":\"4260.058888453676459961899479786112\",\"inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4258.717228926043\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4266.731173804956\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4268.512336271559\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4255.622757413335\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4256.84088323789\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4257.115107072493\"}],\"forecaster_values\":[{\"worker\":\"allo12xax6td0vn7esy3qm54zh0ft96pdtwa4k5gx3j\",\"value\":\"4265.334928248429414133097399752205\"},{\"worker\":\"allo1f07yhttcu6lggaleyd5r4jsgq85dfgsctze2zp\",\"value\":\"4266.553604025666027799103472337839\"},{\"worker\":\"allo1m9vghpc32w8maw8vpp6p55fmcyqkn487r45zwc\",\"value\":\"4258.402653769247209906531611778854\"},{\"worker\":\"allo1s5pkkvwl59egqxqrt7a7w23080grn66m45fcvk\",\"value\":\"4263.409788301422812371839387304860\"},{\"worker\":\"allo1zp8xepd92t4wpk2nkc63h59zwh20k5mkt28h9v\",\"value\":\"4256.903303290942674493133192340247\"}],\"naive_value\":\"4261.487792717884703618835666099610\",\"one_out_inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4261.629525747233142638004864061041\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4260.950839924766922792074594383964\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4256.780574390552917891247612687207\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4262.333474556632243605888821084564\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4260.489454645500301969335522729136\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4258.237143909351667290466580716167\"}],\"one_out_forecaster_values\":[{\"worker\":\"allo12xax6td0vn7esy3qm54zh0ft96pdtwa4k5gx3j\",\"value\":\"4262.737127885234402608216256910918\"},{\"worker\":\"allo1f07yhttcu6lggaleyd5r4jsgq85dfgsctze2zp\",\"value\":\"4259.469168545268139754128228685300\"},{\"worker\":\"allo1m9vghpc32w8maw8vpp6p55fmcyqkn487r45zwc\",\"value\":\"4258.054003282994011007962582946369\"},{\"worker\":\"allo1s5pkkvwl59egqxqrt7a7w23080grn66m45fcvk\",\"value\":\"4257.446020948450506996471900654085\"},{\"worker\":\"allo1zp8xepd92t4wpk2nkc63h59zwh20k5mkt28h9v\",\"value\":\"4263.525529189114093138803122307810\"}],\"one_in_forecaster_values\":[{\"worker\":\"allo12xax6td0vn7esy3qm54zh0ft96pdtwa4k5gx3j\",\"value\":\"4258.407103721686426411978526758915\"},{\"worker\":\"allo1f07yhttcu6lggaleyd5r4jsgq85dfgsctze2zp\",\"value\":\"4262.947564136263230881191206474605\"},{\"worker\":\"allo1m9vghpc32w8maw8vpp6p55fmcyqkn487r45zwc\",\"value\":\"4257.526328125464141105132572731330\"},{\"worker\":\"allo1s5pkkvwl59egqxqrt7a7w23080grn66m45fcvk\",\"value\":\"4263.246945385215936188947403709203\"},{\"worker\":\"allo1zp8xepd92t4wpk2nkc63h59zwh20k5mkt28h9v\",\"value\":\"4257.093912622890055713288093432139\"}],\"one_out_inferer_forecaster_values\":[{\"forecaster\":\"allo12xax6td0vn7esy3qm54zh0ft96pdtwa4k5gx3j\",\"one_out_inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4265.334928248429414133097399752205\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4265.301615999440292007150092472805\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4257.622787880989534231669881702046\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4265.353476251888946236458911960557\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4268.422245491813811366406773268938\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4265.334928248429414133097399752205\"}]},{\"forecaster\":\"allo1f07yhttcu6lggaleyd5r4jsgq85dfgsctze2zp\",\"one_out_inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4266.553604025666027799103472337839\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4266.553604025666027799103472337839\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4256.084176848552784792678515729568\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4267.826857432934068038844082132009\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4266.802083729565506838459081957763\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4266.828738195045108258065767453524\"}]},{\"forecaster\":\"allo1m9vghpc32w8maw8vpp6p55fmcyqkn487r45zwc\",\"one_out_inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4258.401368791152243516660551137793\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4258.402653769247209906531611778854\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4257.120230062856435435352716073856\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4258.406177415926855351148912558617\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4258.403122144644996407640485848506\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4268.007471837821004438872125741721\"}]},{\"forecaster\":\"allo1s5pkkvwl59egqxqrt7a7w23080grn66m45fcvk\",\"one_out_inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4263.409788301422812371839387304860\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4263.409551101135742744428929354313\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4256.973642132448200109218467043041\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4263.409788301422812371839387304860\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4265.378931101917931545088471560074\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4265.098306459682111282591745611177\"}]},{\"forecaster\":\"allo1zp8xepd92t4wpk2nkc63h59zwh20k5mkt28h9v\",\"one_out_inferer_values\":[{\"worker\":\"allo1968fa6rwwytemeqw3aqm97gu34j2mntp2zx5a0\",\"value\":\"4256.902860050894136513728074286840\"},{\"worker\":\"allo19qefnmnx0tq40hppjy2gdwnsm8y77405hxfnvq\",\"value\":\"4256.903303290942674493133192340247\"},{\"worker\":\"allo1aujlfklcxn26u6302d75ufsn0887zpjtl354ek\",\"value\":\"4256.771800157246747608627545994700\"},{\"worker\":\"allo1qdusx2g4yszg37w8ae68j7usmksexzvsdnmkf9\",\"value\":\"4257.014623609612259078642713849193\"},{\"worker\":\"allo1sup3qzm00n7790w30p4tdkkqh3saw2p6nd956w\",\"value\":\"4257.159570928852848925230697058028\"},{\"worker\":\"allo1tj7aghwhudntj6t8eg4fz3cygqpxm94smeyxpz\",\"value\":\"4256.878586322038540946238764444254\"}]}]}"
             ],
@@ -2988,15 +2988,15 @@
             [
                 "\"5828527245427720480\""
             ],
-            "emissions.v9.EventWorkerLastCommitSet.nonce":
+            "emissions.v10.EventWorkerLastCommitSet.nonce":
             [
                 "{\"block_height\":\"5100955\"}"
             ],
-            "emissions.v9.EventWorkerLastCommitSet.topic_id":
+            "emissions.v10.EventWorkerLastCommitSet.topic_id":
             [
                 "\"13\""
             ],
-            "emissions.v9.EventWorkerLastCommitSet.mode":
+            "emissions.v10.EventWorkerLastCommitSet.mode":
             [
                 "EndBlock"
             ],
@@ -3012,7 +3012,7 @@
                 "5828527245427720480uallo",
                 "33650935918233uallo"
             ],
-            "emissions.v9.EventNetworkInferences.block_height":
+            "emissions.v10.EventNetworkInferences.block_height":
             [
                 "\"5100955\""
             ],
@@ -3033,7 +3033,7 @@
                 "allo12uxa8rw9hte3z2nuswjzpmfen289n30uag6agp",
                 "allo17099f3pwtd7u0je2x3ajrem6cfydj9xj5ccq2a"
             ],
-            "emissions.v9.EventTopicRewardsSet.topic_ids":
+            "emissions.v10.EventTopicRewardsSet.topic_ids":
             [
                 "[\"50\"]"
             ],
@@ -3050,7 +3050,7 @@
             [
                 "BeginBlock"
             ],
-            "emissions.v9.EventNetworkInferences.topic_id":
+            "emissions.v10.EventNetworkInferences.topic_id":
             [
                 "\"13\""
             ],
@@ -3136,11 +3136,11 @@
             [
                 "BeginBlock"
             ],
-            "emissions.v9.EventNetworkInferences.mode":
+            "emissions.v10.EventNetworkInferences.mode":
             [
                 "EndBlock"
             ],
-            "emissions.v9.EventWorkerLastCommitSet.block_height":
+            "emissions.v10.EventWorkerLastCommitSet.block_height":
             [
                 "\"5100967\""
             ],

--- a/tests/test_reputer_loss_safety.py
+++ b/tests/test_reputer_loss_safety.py
@@ -20,7 +20,7 @@ def _make_labeled_value(value: str) -> Mock:
     lv = Mock()
     lv.value = value
     lv.label_id = 0
-    lv.label_name = ""
+    lv.label_name = "y"
     return lv
 
 
@@ -44,8 +44,8 @@ def reputer_with_sqe():
     wallet.address.return_value = Mock(__str__=lambda: "allo1abc")
     client = Mock()
 
-    async def reputer_fn(_ctx, prediction: float) -> float:
-        return squared_error_loss(10.0, prediction)
+    async def reputer_fn(_ctx, prediction: dict[str, float]) -> float:
+        return squared_error_loss(10.0, prediction["y"])
 
     return Reputer(
         wallet=wallet,
@@ -63,15 +63,14 @@ class TestComputeLossBundleNonFinite:
         vb = _make_value_bundle(combined_value="nan", naive_value="0")
         with pytest.raises(ValueError) as exc_info:
             await reputer_with_sqe._compute_loss_bundle(vb)
-        assert "predicted" in str(exc_info.value)
-        assert "finite" in str(exc_info.value).lower()
+        assert "non-finite" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
     async def test_predicted_inf_in_combined_raises(self, reputer_with_sqe):
         vb = _make_value_bundle(combined_value="inf", naive_value="0")
         with pytest.raises(ValueError) as exc_info:
             await reputer_with_sqe._compute_loss_bundle(vb)
-        assert "predicted" in str(exc_info.value)
+        assert "non-finite" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
     async def test_finite_values_succeed(self, reputer_with_sqe):

--- a/tests/test_reputer_loss_safety.py
+++ b/tests/test_reputer_loss_safety.py
@@ -16,10 +16,19 @@ from allora_sdk.worker.reputer import Reputer
 # ---------------------------------------------------------------------------
 
 
+def _make_labeled_value(value: str) -> Mock:
+    lv = Mock()
+    lv.value = value
+    lv.label_id = 0
+    lv.label_name = ""
+    return lv
+
+
 def _make_value_bundle(combined_value: str, naive_value: str = "0") -> Mock:
     vb = Mock()
-    vb.combined_value = combined_value
-    vb.naive_value = naive_value
+    vb.combined_value = [_make_labeled_value(combined_value)]
+    vb.naive_value = [_make_labeled_value(naive_value)]
+    vb.nonce = 12345
     vb.inferer_values = []
     vb.forecaster_values = []
     vb.one_out_inferer_values = []

--- a/tests/test_reputer_submit.py
+++ b/tests/test_reputer_submit.py
@@ -23,10 +23,19 @@ def _make_client() -> Mock:
     return client
 
 
+def _make_labeled_value(value: str) -> Mock:
+    lv = Mock()
+    lv.value = value
+    lv.label_id = 0
+    lv.label_name = ""
+    return lv
+
+
 def _make_value_bundle() -> Mock:
     bundle = Mock()
-    bundle.combined_value = "8.0"
-    bundle.naive_value = "9.0"
+    bundle.combined_value = [_make_labeled_value("8.0")]
+    bundle.naive_value = [_make_labeled_value("9.0")]
+    bundle.nonce = 123
     bundle.inferer_values = []
     bundle.forecaster_values = []
     bundle.one_out_inferer_values = []

--- a/tests/test_sequence_safety.py
+++ b/tests/test_sequence_safety.py
@@ -180,8 +180,9 @@ class TestReputerSequenceSafePath:
         mock_client.emissions.query.get_network_inferences_at_block = AsyncMock(
             return_value=MagicMock(
                 network_inferences=MagicMock(
-                    combined_value="1.0",
-                    naive_value="1.0",
+                    combined_value=[MagicMock(value="1.0", label_id=0, label_name="")],
+                    naive_value=[MagicMock(value="1.0", label_id=0, label_name="")],
+                    nonce=100,
                     inferer_values=[],
                     forecaster_values=[],
                     one_out_inferer_values=[],
@@ -236,8 +237,9 @@ class TestReputerSequenceSafePath:
         mock_client.emissions.query.get_network_inferences_at_block = AsyncMock(
             return_value=MagicMock(
                 network_inferences=MagicMock(
-                    combined_value="1.0",
-                    naive_value="1.0",
+                    combined_value=[MagicMock(value="1.0", label_id=0, label_name="")],
+                    naive_value=[MagicMock(value="1.0", label_id=0, label_name="")],
+                    nonce=100,
                     inferer_values=[],
                     forecaster_values=[],
                     one_out_inferer_values=[],
@@ -300,8 +302,9 @@ class TestReputerSequenceSafePath:
         mock_client.emissions.query.get_network_inferences_at_block = AsyncMock(
             return_value=MagicMock(
                 network_inferences=MagicMock(
-                    combined_value="1.0",
-                    naive_value="1.0",
+                    combined_value=[MagicMock(value="1.0", label_id=0, label_name="")],
+                    naive_value=[MagicMock(value="1.0", label_id=0, label_name="")],
+                    nonce=100,
                     inferer_values=[],
                     forecaster_values=[],
                     one_out_inferer_values=[],

--- a/tests/test_tx_manager_simulation.py
+++ b/tests/test_tx_manager_simulation.py
@@ -48,13 +48,13 @@ async def test_submit_transaction_falls_back_when_simulation_raises_tx_error(mon
     monkeypatch.setattr(asyncio, "create_task", _capture_task)
 
     pending = await manager.submit_transaction(
-        type_url="/emissions.v9.InsertWorkerPayloadRequest",
+        type_url="/emissions.v10.InsertWorkerPayloadRequest",
         msgs=[Mock()],
         fee_tier=FeeTier.STANDARD,
     )
 
     # Current behavior: simulation errors are swallowed and gas falls back to defaults.
-    assert pending.type_url == "/emissions.v9.InsertWorkerPayloadRequest"
+    assert pending.type_url == "/emissions.v10.InsertWorkerPayloadRequest"
     manager._attempt_submissions.assert_called_once()
     args, kwargs = manager._attempt_submissions.call_args
     assert args[1] is None  # gas_limit
@@ -80,7 +80,7 @@ async def test_submit_transaction_uses_simulated_gas_when_available(monkeypatch:
     monkeypatch.setattr(asyncio, "create_task", _capture_task)
 
     await manager.submit_transaction(
-        type_url="/emissions.v9.InsertWorkerPayloadRequest",
+        type_url="/emissions.v10.InsertWorkerPayloadRequest",
         msgs=[Mock()],
         fee_tier=FeeTier.PRIORITY,
     )

--- a/tests/test_worker_review_fixes.py
+++ b/tests/test_worker_review_fixes.py
@@ -79,10 +79,10 @@ async def test_make_reputer_function_uses_single_entry_topic_nonce_cache() -> No
     rep_fn = make_reputer_function(gt_fn, lambda truth, prediction: truth + prediction, log_loss=False)
     client = Mock()
 
-    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 1.0)
-    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 2.0)
-    await rep_fn(RunContext(client=client, topic_id=2, nonce=10), 3.0)
-    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 4.0)
+    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), {"y": 1.0})
+    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), {"y": 2.0})
+    await rep_fn(RunContext(client=client, topic_id=2, nonce=10), {"y": 3.0})
+    await rep_fn(RunContext(client=client, topic_id=1, nonce=10), {"y": 4.0})
 
     assert calls == [(1, 10), (2, 10), (1, 10)]
 


### PR DESCRIPTION
* import protos from `v0.17.0` branch of `allora-chain`
* use v10 protos instead of v9 where applicable
* handle dict valued inferences

The main API changes are: 
* `predict_fn` for inferers can now return a `dict[str, float]` instead of a `float` (it can still return `float`, which will just be converted to `{'y': value}`),
* `reputer_fn` gets a `dict[str, float]` as its second argument (inference) instead of `float`.

This works, but is still somewhat unfinished:
* examples have not been updated
* could have some more tests
* classification loss functions not included yet (but I think the reputer code is a better place for them anyway)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end support for labeled, multi-value topics by upgrading to `emissions.v10`, with canonicalized decimals in inferer and forecaster submissions and correct one‑out inferer–forecaster loss bundling. Updates proto deps to `allora-chain` `v0.17.0` and prevents duplicate nonce resubmissions.

- New Features
  - Inferer `predict_fn` can return `dict[str, float]`; scalars auto-wrap as `{'y': value}`. Submissions send `values: list[InputLabeledValue]`; scalar sanity check kept, skipped for multi-output.
  - Reputer `reputer_fn` now receives `dict[str, float]`; losses come from `NetworkInferenceBundle` (`emissions.v10`) with proper one-out inferer–forecaster aggregation.
  - `utils.make_reputer_function` supports multi-output via `multi_output=True`; scalar topics unchanged.
  - RPC/tools migrated to `emissions.v10`: query/WS type URLs, tx type URLs and gas defaults, CSV filter. Forecast and inference values use canonicalized decimals.
  - Worker avoids duplicate nonce resubmissions.

- Migration
  - Update imports from `emissions.v9` to `emissions.v10` (including event classes).
  - Inferers: return dict of label -> value for multi-output; scalars still allowed. If calling the client directly, pass `values=[InputLabeledValue(...)]` to `insert_worker_payload`.
  - Reputers: change signature to accept `dict[str, float]`. If using `make_reputer_function`, pass `multi_output=True` for multi-output topics.
  - Proto deps: switch to `allora-chain` tag `v0.17.0`.

<sup>Written for commit 31653ac27d20bc83889eaf471a3a3873a99befc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







