### PR TITLE
Worker event handling and regular gRPC reconnect

### DIFF
--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -51,19 +51,23 @@ class ReconnectingGRPCChannel(Channel):
 
     When the connection exceeds max_age_secs, the old connection is replaced
     immediately so new RPCs use a fresh connection. The old connection is closed
-    after a short delay (5s) to allow in-flight RPCs to complete.
+    after a short delay (drain_window_secs) to allow in-flight RPCs to complete.
     """
 
-    def __init__(self, *args: Any, max_age_secs: int = 1800, **kwargs: Any):
+    def __init__(self, *args: Any, max_age_secs: int = 1800, drain_window_secs: int = 5, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._max_age_secs = max_age_secs
+        self._drain_window_secs = drain_window_secs
         self._connected_at: Optional[float] = None
         self._cleanup_task: Optional[asyncio.Task[None]] = None
 
     async def _close_old_protocol(self, old_protocol: H2Protocol) -> None:
         """Wait briefly for in-flight RPCs, then close the old connection."""
-        await asyncio.sleep(5)
-        old_protocol.processor.close()
+        await asyncio.sleep(self._drain_window_secs)
+        try:
+            old_protocol.processor.close()
+        except Exception as e:
+            logger.warning(f"Error closing old gRPC connection: {e}")
 
     async def __connect__(self) -> H2Protocol:
         if (
@@ -125,6 +129,7 @@ class AlloraRPCClient:
                 port=parsed_url.port,
                 ssl=parsed_url.secure,
                 max_age_secs=self.network.grpc_max_connection_age_secs,
+                drain_window_secs=self.network.grpc_drain_window_secs,
             )
 
             # Set up gRPC services
@@ -241,11 +246,12 @@ class AlloraRPCClient:
     def testnet(
         cls,
         wallet: Optional[AlloraWalletConfig] = None,
+        network: Optional[AlloraNetworkConfig] = None,
         debug: bool = False,
     ) -> 'AlloraRPCClient':
         """Create client for testnet."""
         return cls(
-            network=AlloraNetworkConfig.testnet(),
+            network=network or AlloraNetworkConfig.testnet(),
             wallet=wallet,
             debug=debug
         )
@@ -255,11 +261,12 @@ class AlloraRPCClient:
     def mainnet(
         cls,
         wallet: Optional[AlloraWalletConfig] = None,
+        network: Optional[AlloraNetworkConfig] = None,
         debug: bool = False,
     ) -> 'AlloraRPCClient':
         """Create client for mainnet."""
         return cls(
-            network=AlloraNetworkConfig.mainnet(),
+            network=network or AlloraNetworkConfig.mainnet(),
             wallet=wallet,
             debug=debug
         )
@@ -267,13 +274,13 @@ class AlloraRPCClient:
     @classmethod
     def local(
         cls,
-        port: int = 26657,
         wallet: Optional[AlloraWalletConfig] = None,
+        network: Optional[AlloraNetworkConfig] = None,
         debug: bool = False,
     ) -> 'AlloraRPCClient':
         """Create client for local development."""
         return cls(
-            network=AlloraNetworkConfig.local(port=port),
+            network=network or AlloraNetworkConfig.local(),
             wallet=wallet,
             debug=debug
         )

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -9,6 +9,7 @@ The client can make queries, submit transactions, and subscribe to websocket eve
 provided it is given the appropriate configuration.
 """
 
+import asyncio
 import logging
 import time
 from typing import Any, Optional, cast
@@ -46,12 +47,23 @@ logger = logging.getLogger("allora_sdk")
 
 
 class ReconnectingGRPCChannel(Channel):
-    """Channel subclass that forces a reconnect after a configurable max age."""
+    """Channel subclass that forces a reconnect after a configurable max age.
+
+    When the connection exceeds max_age_secs, the old connection is replaced
+    immediately so new RPCs use a fresh connection. The old connection is closed
+    after a short delay (5s) to allow in-flight RPCs to complete.
+    """
 
     def __init__(self, *args: Any, max_age_secs: int = 1800, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._max_age_secs = max_age_secs
         self._connected_at: Optional[float] = None
+        self._cleanup_task: Optional[asyncio.Task[None]] = None
+
+    async def _close_old_protocol(self, old_protocol: H2Protocol) -> None:
+        """Wait briefly for in-flight RPCs, then close the old connection."""
+        await asyncio.sleep(5)
+        old_protocol.processor.close()
 
     async def __connect__(self) -> H2Protocol:
         if (
@@ -60,8 +72,10 @@ class ReconnectingGRPCChannel(Channel):
             and time.monotonic() - self._connected_at > self._max_age_secs
         ):
             logger.info("gRPC connection exceeded max age, reconnecting")
-            self.close()
+            old_protocol = self._protocol
+            self._protocol = None  # this also sets self._connected = False
             self._connected_at = None
+            self._cleanup_task = asyncio.create_task(self._close_old_protocol(old_protocol))
 
         was_connected = self._connected
         protocol = await super().__connect__()

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -10,9 +10,11 @@ provided it is given the appropriate configuration.
 """
 
 import logging
-from typing import Optional, cast
+import time
+from typing import Any, Optional, cast
 
 from grpclib.client import Channel
+from grpclib.protocol import H2Protocol
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.urls import Protocol, parse_url
 from cosmpy.aerial.wallet import LocalWallet
@@ -41,6 +43,31 @@ from .client_websocket_events import AlloraWebsocketSubscriber
 from .tx_manager import TxManager
 
 logger = logging.getLogger("allora_sdk")
+
+
+class ReconnectingGRPCChannel(Channel):
+    """Channel subclass that forces a reconnect after a configurable max age."""
+
+    def __init__(self, *args: Any, max_age_secs: int = 1800, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._max_age_secs = max_age_secs
+        self._connected_at: Optional[float] = None
+
+    async def __connect__(self) -> H2Protocol:
+        if (
+            self._connected_at is not None
+            and self._connected
+            and time.monotonic() - self._connected_at > self._max_age_secs
+        ):
+            logger.info("gRPC connection exceeded max age, reconnecting")
+            self.close()
+            self._connected_at = None
+
+        was_connected = self._connected
+        protocol = await super().__connect__()
+        if not was_connected:
+            self._connected_at = time.monotonic()
+        return protocol
 
 
 class AlloraRPCClient:
@@ -79,7 +106,12 @@ class AlloraRPCClient:
         parsed_url = parse_url(self.network.url)
 
         if parsed_url.protocol == Protocol.GRPC:
-            self.grpc_client = Channel(host=parsed_url.hostname, port=parsed_url.port, ssl=parsed_url.secure)
+            self.grpc_client = ReconnectingGRPCChannel(
+                host=parsed_url.hostname,
+                port=parsed_url.port,
+                ssl=parsed_url.secure,
+                max_age_secs=self.network.grpc_max_connection_age_secs,
+            )
 
             # Set up gRPC services
             auth_query = cast(rest.CosmosAuthV1Beta1QueryLike, cosmos_auth_v1beta1.QueryStub(self.grpc_client))

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -58,6 +58,7 @@ class AlloraNetworkConfig:
     gas_price_cache_ttl_secs: int = 30
     congestion_aware_fees: bool = False
     query_timeout_secs: int = 10
+    grpc_max_connection_age_secs: int = 1800
 
     @classmethod
     def testnet(

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -59,6 +59,7 @@ class AlloraNetworkConfig:
     congestion_aware_fees: bool = False
     query_timeout_secs: int = 10
     grpc_max_connection_age_secs: int = 1800
+    grpc_drain_window_secs: int = 5
 
     @classmethod
     def testnet(
@@ -73,6 +74,8 @@ class AlloraNetworkConfig:
         dynamic_gas_price_default_multiplier=3.0,
         gas_price_cache_ttl_secs=30,
         congestion_aware_fees=False,
+        grpc_max_connection_age_secs=1800,
+        grpc_drain_window_secs=5,
     ) -> 'AlloraNetworkConfig':
         return cls(
             chain_id=chain_id,
@@ -85,6 +88,8 @@ class AlloraNetworkConfig:
             dynamic_gas_price_default_multiplier=dynamic_gas_price_default_multiplier,
             gas_price_cache_ttl_secs=gas_price_cache_ttl_secs,
             congestion_aware_fees=congestion_aware_fees,
+            grpc_max_connection_age_secs=grpc_max_connection_age_secs,
+            grpc_drain_window_secs=grpc_drain_window_secs,
         )
 
     @classmethod
@@ -99,6 +104,8 @@ class AlloraNetworkConfig:
         dynamic_gas_price_default_multiplier=3.0,
         gas_price_cache_ttl_secs=30,
         congestion_aware_fees=False,
+        grpc_max_connection_age_secs=1800,
+        grpc_drain_window_secs=5,
     ) -> 'AlloraNetworkConfig':
         return cls(
             chain_id=chain_id,
@@ -110,6 +117,8 @@ class AlloraNetworkConfig:
             dynamic_gas_price_default_multiplier=dynamic_gas_price_default_multiplier,
             gas_price_cache_ttl_secs=gas_price_cache_ttl_secs,
             congestion_aware_fees=congestion_aware_fees,
+            grpc_max_connection_age_secs=grpc_max_connection_age_secs,
+            grpc_drain_window_secs=grpc_drain_window_secs,
         )
 
     @classmethod
@@ -124,6 +133,8 @@ class AlloraNetworkConfig:
         gas_price_cache_ttl_secs=30,
         congestion_aware_fees=False,
         query_timeout_secs=30,
+        grpc_max_connection_age_secs=1800,
+        grpc_drain_window_secs=5,
         port: int = 9090,
         url: str | None = None,
     ) -> 'AlloraNetworkConfig':
@@ -138,6 +149,8 @@ class AlloraNetworkConfig:
             gas_price_cache_ttl_secs=gas_price_cache_ttl_secs,
             congestion_aware_fees=congestion_aware_fees,
             query_timeout_secs=query_timeout_secs,
+            grpc_max_connection_age_secs=grpc_max_connection_age_secs,
+            grpc_drain_window_secs=grpc_drain_window_secs,
         )
 
     @classmethod

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -643,7 +643,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _handle_submission_window_opened_event(self, event: SubmissionWindowOpenEventType, height: int):
         if isinstance(event, EventWorkerSubmissionWindowOpened):
             logger.info(f"🚀 Worker submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
-        else:
+        elif isinstance(event, EventReputerSubmissionWindowOpened):
             logger.info(f"🚀 Reputer submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
 
         if not isinstance(event, self.use_case.submission_window_event_type()):

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -321,7 +321,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
         self._ctx: Optional[Context] = None
         self._queue: Optional[asyncio.Queue[TQueueItem[WorkerFnReturnType]]] = None
-        self._subscription_id: Optional[str] = None
+        self._subscription_ids: list[str] = []
 
 
     async def _ensure_initialized(self):
@@ -601,27 +601,31 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _subscribe_websocket_events(self):
         await self._ensure_initialized()
 
-        await self.client.events.subscribe_new_block_events_typed(
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventWorkerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             self._handle_submission_window_opened_event,
         )
-        await self.client.events.subscribe_new_block_events_typed(
+        self._subscription_ids.append(id)
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             self._handle_submission_window_opened_event,
         )
+        self._subscription_ids.append(id)
 
-        await self.client.events.subscribe_new_block_events_typed(
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventWorkerSubmissionWindowClosed,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             lambda evt, height: logger.info(f"✨ Worker submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
-        await self.client.events.subscribe_new_block_events_typed(
+        self._subscription_ids.append(id)
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowClosed,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             lambda evt, height: logger.info(f"✨ Reputer submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
+        self._subscription_ids.append(id)
 
         # Subscribe to rewards events for autostaking if configured on the use case
         if isinstance(self.use_case, SupportsAutoStake) and self.use_case.autostake is not None:
@@ -638,16 +642,12 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _handle_submission_window_opened_event(self, event: SubmissionWindowOpenEventType, height: int):
         if isinstance(event, EventWorkerSubmissionWindowOpened):
             logger.info(f"🚀 Worker submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
-
-            # reputers only handle EventReputerSubmissionWindowOpened
-            if self.use_case.name() == 'reputer':
-                return
         else:
             logger.info(f"🚀 Reputer submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
 
-            # inferers and forecasters only handle EventWorkerSubmissionWindowOpened
-            if self.use_case.name() == 'inferer' or self.use_case.name() == 'forecaster':
-                return
+        if not isinstance(event, self.use_case.submission_window_event_type()):
+            # wrong type of window (worker/reputer)
+            return
 
         await self._ensure_initialized()
 
@@ -777,14 +777,13 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _cleanup(self, ctx: Context):
         logger.debug("Cleaning up worker resources")
 
-        if self._subscription_id:
+        for id in self._subscription_ids:
             try:
-                await self.client.events.unsubscribe(self._subscription_id)
+                await self.client.events.unsubscribe(id)
                 logger.debug("WebSocket subscription cancelled")
             except Exception as e:
                 logger.warning(f"Error during unsubscribe: {e}")
-            finally:
-                self._subscription_id = None
+        self._subscription_ids.clear()
 
         await ctx.cleanup()
         self._queue = None

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -629,11 +629,12 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
         # Subscribe to rewards events for autostaking if configured on the use case
         if isinstance(self.use_case, SupportsAutoStake) and self.use_case.autostake is not None:
-            await self.client.events.subscribe_new_block_events_typed(
+            id = await self.client.events.subscribe_new_block_events_typed(
                 EventRewardsSettled,
                 [EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"')],
                 self.use_case.handle_rewards_settled,
             )
+            self._subscription_ids.append(id)
             logger.info(
                 f"   Auto-stake enabled: subscribed to rewards events for topic {self.topic_id}"
             )

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -595,31 +595,32 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
             await asyncio.sleep(self.polling_interval)
 
-        logger.debug(f"🔄 Polling worker stopped for topic {self.topic_id}")
+        logger.info(f"🔄 Polling worker stopped for topic {self.topic_id}")
 
 
     async def _subscribe_websocket_events(self):
         await self._ensure_initialized()
 
-        self._subscription_id = await self.client.events.subscribe_new_block_events_typed(
-            self.use_case.submission_window_event_type(),
+        await self.client.events.subscribe_new_block_events_typed(
+            EventWorkerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             self._handle_submission_window_opened_event,
         )
         await self.client.events.subscribe_new_block_events_typed(
-            EventWorkerSubmissionWindowClosed,
-            [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
-            lambda evt, height: logger.info(f"✨ Worker submission window closed (topic={evt.topic_id} nonce={evt.nonce_block_height} height={height})"),
-        )
-        await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
-            lambda evt, height: logger.info(f"🚀 Reputer submission window opened (topic={evt.topic_id} nonce={evt.nonce_block_height} height={height})"),
+            self._handle_submission_window_opened_event,
+        )
+
+        await self.client.events.subscribe_new_block_events_typed(
+            EventWorkerSubmissionWindowClosed,
+            [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
+            lambda evt, height: logger.info(f"✨ Worker submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
         await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowClosed,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
-            lambda evt, height: logger.info(f"✨ Reputer submission window closed (topic={evt.topic_id} nonce={evt.nonce_block_height} height={height})"),
+            lambda evt, height: logger.info(f"✨ Reputer submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
 
         # Subscribe to rewards events for autostaking if configured on the use case
@@ -635,14 +636,24 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
 
     async def _handle_submission_window_opened_event(self, event: SubmissionWindowOpenEventType, height: int):
+        if isinstance(event, EventWorkerSubmissionWindowOpened):
+            logger.info(f"🚀 Worker submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
+
+            # reputers only handle EventReputerSubmissionWindowOpened
+            if self.use_case.name() == 'reputer':
+                return
+        else:
+            logger.info(f"🚀 Reputer submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
+
+            # inferers and forecasters only handle EventWorkerSubmissionWindowOpened
+            if self.use_case.name() == 'inferer' or self.use_case.name() == 'forecaster':
+                return
+
         await self._ensure_initialized()
 
         ctx = self._ctx
         if ctx is None or ctx.is_cancelled():
             return
-
-        role_name = self.use_case.name().capitalize()
-        logger.info(f"🚀 {role_name} submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
 
         try:
             await self._maybe_submit(ctx, event.nonce_block_height)


### PR DESCRIPTION
This fixes two different reliability issues:
* We observed errors in gRPC queries about once per hour when connected to a node hosted on GCP. This seems to be a limitation of GCP's gRPC load balancer, which kills connections after an hour. As a workaround, automatically reconnect before the next query if the connection age exceeds 30 minutes.
* The "Worker/Reputer submission window opened/closed" messages were registered as handlers to the same event as the actual worker payload. But it seems like only one handler per event is allowed, and if two are registered, one of them (seemingly chosen at random) will be ignored. The consequence was that the reputer application would sometimes do nothing except showing window opened/closed messages. Fixed this by combining both the message and the actual functionality into one handler.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve reliability by adding timed gRPC reconnects and consolidating worker/reputer event handling so submissions run consistently. Prevents hourly gRPC drop-offs on GCP and removes missed-event races.

- **Bug Fixes**
  - Use `ReconnectingGRPCChannel` to force gRPC reconnect when the connection exceeds a configurable max age (default 1800s via `AlloraNetworkConfig.grpc_max_connection_age_secs`); drain and close the old connection after `grpc_drain_window_secs` (default 5s). `AlloraRPCClient.testnet/mainnet/local` now accept a custom `AlloraNetworkConfig` to override these.
  - Subscribe to both Worker and Reputer submission-window opened events with one handler; log which opened and only submit for the active role; log closed events.
  - Track all WebSocket subscription IDs (including autostake) and unsubscribe on cleanup; raise polling-stop log to info; improve event logs.

<sup>Written for commit c2262db0753f794b77e244acb179759fa2c5a4de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



