### PR TITLE
fix: idle-gate gRPC reconnect and clean up autostake subscription

### DIFF
--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -46,18 +46,34 @@ logger = logging.getLogger("allora_sdk")
 
 
 class ReconnectingGRPCChannel(Channel):
-    """Channel subclass that forces a reconnect after a configurable max age."""
+    """Channel subclass that forces a reconnect after a configurable max age.
+
+    The reconnect is deferred until no other request is in flight, so it never
+    aborts a concurrent RPC. On a channel that is continuously busy the recycle
+    may be postponed past `max_age_secs`; callers relying on the recycle to dodge
+    a server-side connection cap should tolerate a transient error on the next
+    request in that rare case and retry.
+    """
 
     def __init__(self, *args: Any, max_age_secs: int = 1800, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._max_age_secs = max_age_secs
         self._connected_at: Optional[float] = None
 
+    @property
+    def _in_flight_calls(self) -> int:
+        # grpclib brackets each request: _calls_started in Stream.__aenter__,
+        # _calls_succeeded/_calls_failed in Stream.__aexit__.
+        return self._calls_started - self._calls_succeeded - self._calls_failed
+
     async def __connect__(self) -> H2Protocol:
+        # Only recycle when this is the only in-flight call, so closing the
+        # channel cannot abort a concurrent request (e.g. a tx broadcast).
         if (
             self._connected_at is not None
             and self._connected
             and time.monotonic() - self._connected_at > self._max_age_secs
+            and self._in_flight_calls <= 1
         ):
             logger.info("gRPC connection exceeded max age, reconnecting")
             self.close()

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -10,9 +10,11 @@ provided it is given the appropriate configuration.
 """
 
 import logging
-from typing import Optional, cast
+import time
+from typing import Any, Optional, cast
 
 from grpclib.client import Channel
+from grpclib.protocol import H2Protocol
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.urls import Protocol, parse_url
 from cosmpy.aerial.wallet import LocalWallet
@@ -41,6 +43,31 @@ from .client_websocket_events import AlloraWebsocketSubscriber
 from .tx_manager import TxManager
 
 logger = logging.getLogger("allora_sdk")
+
+
+class ReconnectingGRPCChannel(Channel):
+    """Channel subclass that forces a reconnect after a configurable max age."""
+
+    def __init__(self, *args: Any, max_age_secs: int = 1800, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._max_age_secs = max_age_secs
+        self._connected_at: Optional[float] = None
+
+    async def __connect__(self) -> H2Protocol:
+        if (
+            self._connected_at is not None
+            and self._connected
+            and time.monotonic() - self._connected_at > self._max_age_secs
+        ):
+            logger.info("gRPC connection exceeded max age, reconnecting")
+            self.close()
+            self._connected_at = None
+
+        was_connected = self._connected
+        protocol = await super().__connect__()
+        if not was_connected:
+            self._connected_at = time.monotonic()
+        return protocol
 
 
 class AlloraRPCClient:
@@ -79,7 +106,12 @@ class AlloraRPCClient:
         parsed_url = parse_url(self.network.url)
 
         if parsed_url.protocol == Protocol.GRPC:
-            self.grpc_client = Channel(host=parsed_url.hostname, port=parsed_url.port, ssl=parsed_url.secure)
+            self.grpc_client = ReconnectingGRPCChannel(
+                host=parsed_url.hostname,
+                port=parsed_url.port,
+                ssl=parsed_url.secure,
+                max_age_secs=self.network.grpc_max_connection_age_secs,
+            )
 
             # Set up gRPC services
             auth_query = cast(rest.CosmosAuthV1Beta1QueryLike, cosmos_auth_v1beta1.QueryStub(self.grpc_client))

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -58,6 +58,7 @@ class AlloraNetworkConfig:
     gas_price_cache_ttl_secs: int = 30
     congestion_aware_fees: bool = False
     query_timeout_secs: int = 10
+    grpc_max_connection_age_secs: int = 1800
 
     @classmethod
     def testnet(

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -321,7 +321,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
         self._ctx: Optional[Context] = None
         self._queue: Optional[asyncio.Queue[TQueueItem[WorkerFnReturnType]]] = None
-        self._subscription_id: Optional[str] = None
+        self._subscription_ids: list[str] = []
 
 
     async def _ensure_initialized(self):
@@ -601,27 +601,31 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _subscribe_websocket_events(self):
         await self._ensure_initialized()
 
-        await self.client.events.subscribe_new_block_events_typed(
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventWorkerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             self._handle_submission_window_opened_event,
         )
-        await self.client.events.subscribe_new_block_events_typed(
+        self._subscription_ids.append(id)
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             self._handle_submission_window_opened_event,
         )
+        self._subscription_ids.append(id)
 
-        await self.client.events.subscribe_new_block_events_typed(
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventWorkerSubmissionWindowClosed,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             lambda evt, height: logger.info(f"✨ Worker submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
-        await self.client.events.subscribe_new_block_events_typed(
+        self._subscription_ids.append(id)
+        id = await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowClosed,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             lambda evt, height: logger.info(f"✨ Reputer submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
+        self._subscription_ids.append(id)
 
         # Subscribe to rewards events for autostaking if configured on the use case
         if isinstance(self.use_case, SupportsAutoStake) and self.use_case.autostake is not None:
@@ -638,16 +642,12 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _handle_submission_window_opened_event(self, event: SubmissionWindowOpenEventType, height: int):
         if isinstance(event, EventWorkerSubmissionWindowOpened):
             logger.info(f"🚀 Worker submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
-
-            # reputers only handle EventReputerSubmissionWindowOpened
-            if self.use_case.name() == 'reputer':
-                return
         else:
             logger.info(f"🚀 Reputer submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
 
-            # inferers and forecasters only handle EventWorkerSubmissionWindowOpened
-            if self.use_case.name() == 'inferer' or self.use_case.name() == 'forecaster':
-                return
+        if not isinstance(event, self.use_case.submission_window_event_type()):
+            # wrong type of window (worker/reputer)
+            return
 
         await self._ensure_initialized()
 
@@ -777,14 +777,13 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
     async def _cleanup(self, ctx: Context):
         logger.debug("Cleaning up worker resources")
 
-        if self._subscription_id:
+        for id in self._subscription_ids:
             try:
-                await self.client.events.unsubscribe(self._subscription_id)
+                await self.client.events.unsubscribe(id)
                 logger.debug("WebSocket subscription cancelled")
             except Exception as e:
                 logger.warning(f"Error during unsubscribe: {e}")
-            finally:
-                self._subscription_id = None
+        self._subscription_ids.clear()
 
         await ctx.cleanup()
         self._queue = None

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -629,11 +629,12 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
         # Subscribe to rewards events for autostaking if configured on the use case
         if isinstance(self.use_case, SupportsAutoStake) and self.use_case.autostake is not None:
-            await self.client.events.subscribe_new_block_events_typed(
+            id = await self.client.events.subscribe_new_block_events_typed(
                 EventRewardsSettled,
                 [EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"')],
                 self.use_case.handle_rewards_settled,
             )
+            self._subscription_ids.append(id)
             logger.info(
                 f"   Auto-stake enabled: subscribed to rewards events for topic {self.topic_id}"
             )

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -595,31 +595,32 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
             await asyncio.sleep(self.polling_interval)
 
-        logger.debug(f"🔄 Polling worker stopped for topic {self.topic_id}")
+        logger.info(f"🔄 Polling worker stopped for topic {self.topic_id}")
 
 
     async def _subscribe_websocket_events(self):
         await self._ensure_initialized()
 
-        self._subscription_id = await self.client.events.subscribe_new_block_events_typed(
-            self.use_case.submission_window_event_type(),
+        await self.client.events.subscribe_new_block_events_typed(
+            EventWorkerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
             self._handle_submission_window_opened_event,
         )
         await self.client.events.subscribe_new_block_events_typed(
-            EventWorkerSubmissionWindowClosed,
-            [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
-            lambda evt, height: logger.info(f"✨ Worker submission window closed (topic={evt.topic_id} nonce={evt.nonce_block_height} height={height})"),
-        )
-        await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowOpened,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
-            lambda evt, height: logger.info(f"🚀 Reputer submission window opened (topic={evt.topic_id} nonce={evt.nonce_block_height} height={height})"),
+            self._handle_submission_window_opened_event,
+        )
+
+        await self.client.events.subscribe_new_block_events_typed(
+            EventWorkerSubmissionWindowClosed,
+            [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
+            lambda evt, height: logger.info(f"✨ Worker submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
         await self.client.events.subscribe_new_block_events_typed(
             EventReputerSubmissionWindowClosed,
             [ EventAttributeCondition("topic_id", "=", f'"{str(self.topic_id)}"') ],
-            lambda evt, height: logger.info(f"✨ Reputer submission window closed (topic={evt.topic_id} nonce={evt.nonce_block_height} height={height})"),
+            lambda evt, height: logger.info(f"✨ Reputer submission window closed (topic={self.topic_id} nonce={evt.nonce_block_height} height={height})"),
         )
 
         # Subscribe to rewards events for autostaking if configured on the use case
@@ -635,14 +636,24 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
 
 
     async def _handle_submission_window_opened_event(self, event: SubmissionWindowOpenEventType, height: int):
+        if isinstance(event, EventWorkerSubmissionWindowOpened):
+            logger.info(f"🚀 Worker submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
+
+            # reputers only handle EventReputerSubmissionWindowOpened
+            if self.use_case.name() == 'reputer':
+                return
+        else:
+            logger.info(f"🚀 Reputer submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
+
+            # inferers and forecasters only handle EventWorkerSubmissionWindowOpened
+            if self.use_case.name() == 'inferer' or self.use_case.name() == 'forecaster':
+                return
+
         await self._ensure_initialized()
 
         ctx = self._ctx
         if ctx is None or ctx.is_cancelled():
             return
-
-        role_name = self.use_case.name().capitalize()
-        logger.info(f"🚀 {role_name} submission window opened (topic={self.topic_id} nonce={event.nonce_block_height} height={height})")
 
         try:
             await self._maybe_submit(ctx, event.nonce_block_height)


### PR DESCRIPTION
# Harden gRPC reconnect and track autostake subscription

Follow-up reliability fixes on top of the gRPC reconnect / worker event-handling work.

## Summary

- Defer the age-based gRPC channel recycle until no other request is in flight, so a reconnect can no longer abort a concurrent RPC (e.g. a tx broadcast).
- Track the autostake `EventRewardsSettled` subscription so it is cleaned up on worker shutdown like the other subscriptions.

## Changes

### `src/allora_sdk/rpc_client/client.py` — idle-gated gRPC reconnect

`ReconnectingGRPCChannel.__connect__` previously closed the channel based only on connection age. Because `__connect__` runs on every request, a recycle could tear down the HTTP/2 connection while another request was mid-flight on the same channel, causing that request to fail (most concerning for a tx broadcast, which could be left in an ambiguous "maybe submitted" state).

The recycle is now gated on the in-flight request count:

- Added an `_in_flight_calls` property derived from grpclib's built-in per-call counters (`_calls_started` is incremented in `Stream.__aenter__`; `_calls_succeeded` / `_calls_failed` in `Stream.__aexit__`).
- The age-based `close()` only runs when `_in_flight_calls <= 1` (i.e. only the current request is active). Since the age check and `close()` execute with no `await` between them, no other coroutine can start a stream in that window, making the gated close race-free within the event loop. The current request is unaffected because its stream is created only after `__connect__` returns the fresh connection.
- If the channel is busy, the recycle is simply deferred to the next eligible `__connect__` (`_connected_at` is left unchanged).
- Updated the `ReconnectingGRPCChannel` docstring to document the deferral policy and the residual caveat: on a continuously busy channel the recycle may be postponed past `max_age_secs`, so callers relying on it to dodge a server-side connection cap should tolerate a transient error on the next request in that rare case and retry.

### `src/allora_sdk/worker/worker.py` — track autostake subscription

The autostake `EventRewardsSettled` subscription was the only websocket subscription not recorded in `self._subscription_ids`, so `_cleanup` never unsubscribed it (leaking it, and risking a duplicate subscription if the worker is re-run on the same client). Its id is now captured and appended to `self._subscription_ids`, consistent with the four submission-window subscriptions.

## Testing

- `pytest tests/`: 156 passed, 3 skipped.
- The added lines are `black`-clean and introduce no new `mypy` errors (remaining `mypy`/lint findings are pre-existing and unrelated).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers gRPC channel recycle until the channel is idle to avoid aborting concurrent RPCs, and ensures the autostake rewards subscription is cleaned up on shutdown.

- **Bug Fixes**
  - gRPC reconnect is now idle-gated: counts in-flight calls via grpclib counters and only recycles when the current call is the only one; defers recycle if busy and updates the docstring.
  - Autostake `EventRewardsSettled` subscription id is now recorded in `_subscription_ids` so it’s unsubscribed on worker shutdown and not duplicated.

<sup>Written for commit d6e51a2ac49c03f40174dcf4f573c99241c7b7dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

