### PR TITLE
Change loss function argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Reputers evaluate inference quality by computing losses between ground truth and
 
 In practice, it is often more convenient to have two separate callbacks:
 1. A ground truth function `get_ground_truth(context: RunContext) -> GroundTruthType` which only runs once per epoch.
-2. A loss function `loss(inference: float, gt: GroundTruthType) -> float`, which runs for every value in the inference bundle
+2. A loss function `loss(gt: GroundTruthType, inference: float) -> float`, which runs for every value in the inference bundle
 
 Note that the ground truth type does not need to agree with the inference type (`float`). That is useful for certain loss functions which require extra data. For example, the `czar` and `ztae` loss functions require a standard deviation of historical values, which can just be treated as part of the ground truth.
 

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -104,7 +104,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
 
     Returns a function that can be passed to `AlloraWorker.reputer()`. The ground truth function
     `gt_fn` is only going to be called once per epoch, then the `loss_fn` gets called once for every
-    value in the `ValueBundle` (passing the fetched ground truth as the second argument).
+    value in the `ValueBundle` (passing the fetched ground truth as the first argument).
 
     The type of the "ground truth" is only used internally, and not exposed by the resulting function.
     This means it can be arbitrarily chosen and is not defined by the topic. For example, if a loss function
@@ -112,7 +112,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
 
     Args:
         gt_fn: Async function that fetches the ground-truth value. The ground truth can be any type.
-        loss_fn: Function that computes a scalar loss given an inference and the ground truth.
+        loss_fn: Function that computes a scalar loss given the ground truth and an inference.
         log_loss: If true, take log10 of each loss value before submitting (the chain expects log losses)
 
     Returns:

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -99,7 +99,7 @@ async def get_network_inference(client: AlloraRPCClient, topic_id: int, nonce: i
     return network_inferences_resp.network_inferences
 
 Truth = TypeVar('Truth')
-def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[float, Truth], float], log_loss: bool = True) -> Callable[[RunContext, float], Awaitable[float]]:
+def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_fn: Callable[[Truth, float], float], log_loss: bool = True) -> Callable[[RunContext, float], Awaitable[float]]:
     """Build a reputer scoring function from separate ground-truth and loss components.
 
     Returns a function that can be passed to `AlloraWorker.reputer()`. The ground truth function
@@ -133,7 +133,7 @@ def make_reputer_function(gt_fn: Callable[[RunContext], Awaitable[Truth]], loss_
 
             logger.info(f'📐 Ground truth for topic {context.topic_id} at nonce {context.nonce}: {gt}')
 
-        loss = loss_fn(inference, gt)
+        loss = loss_fn(gt, inference)
 
         if log_loss:
             loss = math.log10(loss + 1e-100)

--- a/tests/test_worker_review_fixes.py
+++ b/tests/test_worker_review_fixes.py
@@ -76,7 +76,7 @@ async def test_make_reputer_function_uses_single_entry_topic_nonce_cache() -> No
         calls.append((ctx.topic_id, ctx.nonce))
         return float(len(calls))
 
-    rep_fn = make_reputer_function(gt_fn, lambda prediction, truth: prediction + truth, log_loss=False)
+    rep_fn = make_reputer_function(gt_fn, lambda truth, prediction: truth + prediction, log_loss=False)
     client = Mock()
 
     await rep_fn(RunContext(client=client, topic_id=1, nonce=10), 1.0)


### PR DESCRIPTION
All our loss functions use the convention `loss(ground_truth, inference)`, but the SDK expected `loss(inference, ground_truth)` instead. Having the ground truth first seems more common / natural.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized loss function argument order to `loss(ground_truth, inference)` in `allora_sdk` to match our conventions and prevent inverted scoring. Updated README and tests to reflect the new order.

- **Migration**
  - If you pass a custom `loss_fn` to `make_reputer_function`, update it to accept `(truth, inference)` instead of `(inference, truth)`.
  - To keep existing functions, wrap them: `lambda t, y: old_loss(y, t)`.

<sup>Written for commit f59045d6901ae302905f003a27d46829e5b04d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

