### PR TITLE
ENGN-8615: Privy-delegated remote signing (RemoteWallet/RemoteSigner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,18 +320,25 @@ remote = make_remote_wallet(
 worker = AlloraWorker.inferer(
     topic_id=69,
     network=AlloraNetworkConfig.testnet(),
-    wallet=AlloraWalletConfig(wallet=remote),
+    wallet=AlloraWalletConfig(
+        wallet=remote,
+        # Subsidize gas from a master wallet via feegrant (optional).
+        fee_granter=os.environ.get("FEE_GRANTER"),
+    ),
     run=run_model,
 )
 ```
 
-Worker gas can be subsidized by a master-wallet feegrant configured on the backend, so
-the signing wallet needs no ALLO of its own.
+Worker gas can be subsidized by a master-wallet feegrant: set `fee_granter` to the master
+wallet address (which must hold an on-chain feegrant allowance for the signing wallet) and
+transactions are broadcast with that granter as the fee payer, so the signing wallet needs
+no ALLO of its own. Leave `fee_granter` unset to have the signing wallet pay its own fees.
 
 For env-driven (12-factor) deployments, `AlloraWalletConfig.from_env()` builds the remote
 wallet automatically when `FORGE_API_KEY` and `FORGE_SIGNING_WALLET_ID` are set
 (`FORGE_BACKEND_URL` defaults to `https://forge.allora.network`), alongside the existing
-`PRIVATE_KEY` / `MNEMONIC` / `MNEMONIC_FILE` options.
+`PRIVATE_KEY` / `MNEMONIC` / `MNEMONIC_FILE` options. Set `FEE_GRANTER` to enable the
+feegrant subsidy described below.
 
 ## Allora API Client
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,38 @@ Wire protocol is determined by the RPC url string passed to the config construct
 - **Multi-chain**: Testnet and mainnet support come with batteries included, but there is maximal configurability.  Can be used with other Cosmos SDK chains.
 - **Type safety**: Full protobuf type and service definitions, codegen clients
 
+### Privy-Managed (Delegated) Signing
+
+By default the worker signs with a local key (mnemonic / private key / `.allora_key`).
+Alternatively, you can delegate signing to the Forge backend, which signs with a
+Privy-managed server wallet — the worker holds no private key. `make_remote_wallet()`
+returns a cosmpy `Wallet` you pass via `AlloraWalletConfig(wallet=...)`; the worker loop
+and both tx + bundle signing work unchanged.
+
+```python
+import os
+from allora_sdk import (
+    AlloraWorker, AlloraNetworkConfig, AlloraWalletConfig, make_remote_wallet,
+)
+
+# wallet_id + api_key are minted in the Forge web app.
+remote = make_remote_wallet(
+    backend_url="https://forge.allora.network",
+    api_key=os.environ["FORGE_API_KEY"],
+    wallet_id=os.environ["FORGE_SIGNING_WALLET_ID"],
+)
+
+worker = AlloraWorker.inferer(
+    topic_id=69,
+    network=AlloraNetworkConfig.testnet(),
+    wallet=AlloraWalletConfig(wallet=remote),
+    run=run_model,
+)
+```
+
+Worker gas can be subsidized by a master-wallet feegrant configured on the backend, so
+the signing wallet needs no ALLO of its own.
+
 ## Allora API Client
 
 Slim, high-level HTTP client for querying a list of all topics, individual topic metadata, and network inference results.

--- a/README.md
+++ b/README.md
@@ -328,6 +328,11 @@ worker = AlloraWorker.inferer(
 Worker gas can be subsidized by a master-wallet feegrant configured on the backend, so
 the signing wallet needs no ALLO of its own.
 
+For env-driven (12-factor) deployments, `AlloraWalletConfig.from_env()` builds the remote
+wallet automatically when `FORGE_API_KEY` and `FORGE_SIGNING_WALLET_ID` are set
+(`FORGE_BACKEND_URL` defaults to `https://forge.allora.network`), alongside the existing
+`PRIVATE_KEY` / `MNEMONIC` / `MNEMONIC_FILE` options.
+
 ## Allora API Client
 
 Slim, high-level HTTP client for querying a list of all topics, individual topic metadata, and network inference results.

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,5 +1,6 @@
 from .worker import AlloraWorker
 from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig, TxManager, FeeTier
+from .rpc_client import RemoteSigner, RemoteWallet, make_remote_wallet
 from .rpc_client.protos.emissions.v3 import ValueBundle
 from .api_client import AlloraAPIClient
 from .logging_config import setup_sdk_logging
@@ -24,6 +25,9 @@ __all__ = [
     "setup_sdk_logging",
     "LocalWallet",
     "PrivateKey",
+    "RemoteSigner",
+    "RemoteWallet",
+    "make_remote_wallet",
     # Loss methods
     "get_default_loss_fn",
     "is_supported_loss_method",

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,6 +1,13 @@
 from .worker import AlloraWorker
 from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig, TxManager, FeeTier
-from .rpc_client import RemoteSigner, RemoteWallet, make_remote_wallet
+from .rpc_client import (
+    RemoteSigner,
+    RemoteWallet,
+    make_remote_wallet,
+    RemoteSignerError,
+    ForgeBackendError,
+    WalletConfigError,
+)
 from .rpc_client.protos.emissions.v3 import ValueBundle
 from .api_client import AlloraAPIClient
 from .logging_config import setup_sdk_logging
@@ -28,6 +35,9 @@ __all__ = [
     "RemoteSigner",
     "RemoteWallet",
     "make_remote_wallet",
+    "RemoteSignerError",
+    "ForgeBackendError",
+    "WalletConfigError",
     # Loss methods
     "get_default_loss_fn",
     "is_supported_loss_method",

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -7,6 +7,7 @@ from .rpc_client import (
     RemoteSignerError,
     ForgeBackendError,
     WalletConfigError,
+    ForgeBackendClient,
 )
 from .rpc_client.protos.emissions.v3 import ValueBundle
 from .api_client import AlloraAPIClient
@@ -38,6 +39,7 @@ __all__ = [
     "RemoteSignerError",
     "ForgeBackendError",
     "WalletConfigError",
+    "ForgeBackendClient",
     # Loss methods
     "get_default_loss_fn",
     "is_supported_loss_method",

--- a/src/allora_sdk/__init__.py
+++ b/src/allora_sdk/__init__.py
@@ -1,6 +1,10 @@
 from .worker import AlloraWorker
-from .rpc_client import AlloraRPCClient, AlloraNetworkConfig, AlloraWalletConfig, TxManager, FeeTier
 from .rpc_client import (
+    AlloraRPCClient,
+    AlloraNetworkConfig,
+    AlloraWalletConfig,
+    TxManager,
+    FeeTier,
     RemoteSigner,
     RemoteWallet,
     make_remote_wallet,

--- a/src/allora_sdk/rpc_client/__init__.py
+++ b/src/allora_sdk/rpc_client/__init__.py
@@ -1,6 +1,13 @@
 from .client import AlloraRPCClient
 from .config import AlloraNetworkConfig, AlloraWalletConfig
-from .remote_signer import RemoteSigner, RemoteWallet, make_remote_wallet
+from .remote_signer import (
+    ForgeBackendError,
+    RemoteSigner,
+    RemoteSignerError,
+    RemoteWallet,
+    WalletConfigError,
+    make_remote_wallet,
+)
 from .tx_manager import FeeTier, TxManager
 
 
@@ -13,4 +20,7 @@ __all__ = [
     "RemoteSigner",
     "RemoteWallet",
     "make_remote_wallet",
+    "RemoteSignerError",
+    "ForgeBackendError",
+    "WalletConfigError",
 ]

--- a/src/allora_sdk/rpc_client/__init__.py
+++ b/src/allora_sdk/rpc_client/__init__.py
@@ -1,6 +1,7 @@
 from .client import AlloraRPCClient
 from .config import AlloraNetworkConfig, AlloraWalletConfig
 from .remote_signer import (
+    ForgeBackendClient,
     ForgeBackendError,
     RemoteSigner,
     RemoteSignerError,
@@ -23,4 +24,5 @@ __all__ = [
     "RemoteSignerError",
     "ForgeBackendError",
     "WalletConfigError",
+    "ForgeBackendClient",
 ]

--- a/src/allora_sdk/rpc_client/__init__.py
+++ b/src/allora_sdk/rpc_client/__init__.py
@@ -1,5 +1,6 @@
 from .client import AlloraRPCClient
 from .config import AlloraNetworkConfig, AlloraWalletConfig
+from .remote_signer import RemoteSigner, RemoteWallet, make_remote_wallet
 from .tx_manager import FeeTier, TxManager
 
 
@@ -9,4 +10,7 @@ __all__ = [
     "AlloraWalletConfig",
     "TxManager",
     "FeeTier",
+    "RemoteSigner",
+    "RemoteWallet",
+    "make_remote_wallet",
 ]

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -164,6 +164,7 @@ class AlloraRPCClient:
                 feemarket_client=feemarket_query,
                 config=self.network,
                 query_timeout_secs=self.network.query_timeout_secs,
+                fee_granter=self._fee_granter,
             )
 
         self.auth       = AuthClient(query_client=auth_query, tx_manager=self.tx_manager)
@@ -183,6 +184,7 @@ class AlloraRPCClient:
 
     def _initialize_wallet(self, wallet: Optional[AlloraWalletConfig]):
         """Initialize wallet from private key or mnemonic."""
+        self._fee_granter: Optional[str] = wallet.fee_granter if wallet else None
         if not wallet:
             return
 

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -18,7 +18,7 @@ from grpclib.client import Channel
 from grpclib.protocol import H2Protocol
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.urls import Protocol, parse_url
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import LocalWallet, Wallet
 from cosmpy.crypto.keypairs import PrivateKey
 
 import allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 as tendermint_v1beta1
@@ -96,7 +96,7 @@ class AlloraRPCClient:
     including queries, transactions, and event subscriptions.
     """
 
-    wallet: Optional[LocalWallet] = None
+    wallet: Optional[Wallet] = None
     tx_manager: Optional[TxManager] = None
 
     def __init__(

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -191,7 +191,7 @@ class AlloraRPCClient:
         try:
             if wallet.wallet:
                 self.wallet = wallet.wallet
-                logger.debug("Wallet initialized from LocalWallet")
+                logger.debug(f"Wallet initialized from pre-built {type(wallet.wallet).__name__}")
             elif wallet.private_key:
                 pk = PrivateKey(bytes.fromhex(wallet.private_key))
                 self.wallet = LocalWallet(pk, prefix=wallet.prefix)

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -192,15 +192,15 @@ class AlloraRPCClient:
                 logger.debug("Wallet initialized from LocalWallet")
             elif wallet.private_key:
                 pk = PrivateKey(bytes.fromhex(wallet.private_key))
-                self.wallet = LocalWallet(pk, prefix="allo")
+                self.wallet = LocalWallet(pk, prefix=wallet.prefix)
                 logger.debug("Wallet initialized from private key")
             elif wallet.mnemonic:
-                self.wallet = LocalWallet.from_mnemonic(wallet.mnemonic, prefix="allo")
+                self.wallet = LocalWallet.from_mnemonic(wallet.mnemonic, prefix=wallet.prefix)
                 logger.debug("Wallet initialized from mnemonic")
             elif wallet.mnemonic_file:
                 with open(wallet.mnemonic_file) as f:
                     mnemonic = f.read()
-                self.wallet = LocalWallet.from_mnemonic(mnemonic, prefix="allo")
+                self.wallet = LocalWallet.from_mnemonic(mnemonic, prefix=wallet.prefix)
                 logger.debug("Wallet initialized from mnemonic file")
         except Exception as e:
             logger.error(f"Failed to initialize wallet: {e}")

--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -21,7 +21,7 @@ from allora_sdk.rpc_client.protos.emissions.v9 import (
     InputForecast,
     RegisterRequest,
 )
-from allora_sdk.rpc_client.tx_manager import FeeTier, TxManager, PendingTx, WalletNotConfiguredError
+from allora_sdk.rpc_client.tx_manager import FeeTier, TxManager, PendingTx, WalletNotConfiguredError, _signing_executor
 from allora_sdk.rpc_client.rest import EmissionsV9QueryServiceLike
 from allora_sdk.rpc_client.dec_canonical import canonicalize_dec
 
@@ -149,7 +149,10 @@ class EmissionsTxs:
         # Offload to a worker thread: signer() may be a RemoteSigner whose sign_digest
         # makes a blocking HTTPS call to the Forge backend, which would otherwise freeze
         # the event loop (websocket subscriber, other workers, tx monitor).
-        bundle_sig = await asyncio.to_thread(self._txs.wallet.signer().sign_digest, bundle_digest)
+        loop = asyncio.get_running_loop()
+        bundle_sig = await loop.run_in_executor(
+            _signing_executor, self._txs.wallet.signer().sign_digest, bundle_digest
+        )
 
         worker_data_bundle = InputWorkerDataBundle(
             worker=worker_address,
@@ -282,7 +285,10 @@ class EmissionsTxs:
         # Offload to a worker thread: signer() may be a RemoteSigner whose sign_digest
         # makes a blocking HTTPS call to the Forge backend, which would otherwise freeze
         # the event loop (websocket subscriber, other workers, tx monitor).
-        bundle_sig = await asyncio.to_thread(self._txs.wallet.signer().sign_digest, bundle_digest)
+        loop = asyncio.get_running_loop()
+        bundle_sig = await loop.run_in_executor(
+            _signing_executor, self._txs.wallet.signer().sign_digest, bundle_digest
+        )
 
         reputer_value_bundle = InputReputerValueBundle(
             value_bundle=value_bundle,

--- a/src/allora_sdk/rpc_client/client_emissions.py
+++ b/src/allora_sdk/rpc_client/client_emissions.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import logging
 from typing import Dict, List, Optional
@@ -145,7 +146,10 @@ class EmissionsTxs:
         # sign bundle with pubkey using a 32-byte digest (secp256k1 requirement)
         bundle_bytes = bytes(bundle)
         bundle_digest = hashlib.sha256(bundle_bytes).digest()
-        bundle_sig = self._txs.wallet.signer().sign_digest(bundle_digest)
+        # Offload to a worker thread: signer() may be a RemoteSigner whose sign_digest
+        # makes a blocking HTTPS call to the Forge backend, which would otherwise freeze
+        # the event loop (websocket subscriber, other workers, tx monitor).
+        bundle_sig = await asyncio.to_thread(self._txs.wallet.signer().sign_digest, bundle_digest)
 
         worker_data_bundle = InputWorkerDataBundle(
             worker=worker_address,
@@ -275,7 +279,10 @@ class EmissionsTxs:
         # Sign the value bundle
         bundle_bytes = bytes(value_bundle)
         bundle_digest = hashlib.sha256(bundle_bytes).digest()
-        bundle_sig = self._txs.wallet.signer().sign_digest(bundle_digest)
+        # Offload to a worker thread: signer() may be a RemoteSigner whose sign_digest
+        # makes a blocking HTTPS call to the Forge backend, which would otherwise freeze
+        # the event loop (websocket subscriber, other workers, tx monitor).
+        bundle_sig = await asyncio.to_thread(self._txs.wallet.signer().sign_digest, bundle_digest)
 
         reputer_value_bundle = InputReputerValueBundle(
             value_bundle=value_bundle,

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -49,6 +49,18 @@ class AlloraWalletConfig:
                 "Exactly one of private_key, mnemonic, mnemonic_file, or wallet must be provided"
             )
 
+        if self.wallet is not None:
+            # A pre-built wallet fixes its own bech32 prefix at construction time and
+            # downstream code uses the wallet directly, so `prefix` would otherwise be a
+            # silently-ignored, possibly-misleading value. Align it to the wallet's actual
+            # prefix (e.g. a RemoteWallet built with prefix="cosmos").
+            try:
+                hrp = str(self.wallet.address()).split("1", 1)[0]
+            except Exception:
+                hrp = ""
+            if hrp:
+                self.prefix = hrp
+
 
 @dataclass
 class AlloraNetworkConfig:

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -19,17 +19,24 @@ class AlloraWalletConfig:
       delegated to the Forge backend).
 
     The address prefix can also be specified (default is "allo").
+
+    fee_granter optionally sets the bech32 address of a fee granter (a master/subsidy
+    wallet that has created an on-chain feegrant for this wallet). When set, transactions
+    are broadcast with this granter as the fee payer, so the signing wallet needs no ALLO
+    of its own — this is the recommended pairing for Privy-delegated (RemoteWallet) signing.
     """
     private_key: Optional[str] = None
     mnemonic: Optional[str] = None
     mnemonic_file: Optional[str] = None
     wallet: Optional[Wallet] = None
     prefix: str = "allo"
+    fee_granter: Optional[str] = None
 
     @classmethod
     def from_env(cls, env_prefix: str | None = None) -> 'AlloraWalletConfig':
         p = env_prefix or ""
         prefix = os.getenv(p + "ADDRESS_PREFIX", "allo")
+        fee_granter = os.getenv(p + "FEE_GRANTER")
 
         # Privy-delegated signing: if the Forge env vars are present, build a RemoteWallet
         # so 12-factor deployments can use delegated signing without hand-written wiring.
@@ -42,13 +49,14 @@ class AlloraWalletConfig:
 
             backend_url = os.getenv(p + "FORGE_BACKEND_URL", "https://forge.allora.network")
             wallet = make_remote_wallet(backend_url, api_key, wallet_id, prefix=prefix)
-            return cls(wallet=wallet, prefix=prefix)
+            return cls(wallet=wallet, prefix=prefix, fee_granter=fee_granter)
 
         return cls(
             private_key=os.getenv(p + "PRIVATE_KEY"),
             mnemonic=os.getenv(p + "MNEMONIC"),
             mnemonic_file=os.getenv(p + "MNEMONIC_FILE"),
             prefix=prefix,
+            fee_granter=fee_granter,
         )
 
     def __post_init__(self):

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -45,6 +45,21 @@ class AlloraWalletConfig:
         api_key = os.getenv(p + "FORGE_API_KEY")
         wallet_id = os.getenv(p + "FORGE_SIGNING_WALLET_ID")
         if api_key and wallet_id:
+            # The early return below never reads PRIVATE_KEY/MNEMONIC/MNEMONIC_FILE, so a
+            # stale local-key env var (a common mid-migration state) would be silently
+            # ignored and signing would go through Forge with no log. Mirror __post_init__'s
+            # "exactly one credential source" guard at the env layer and fail loudly instead.
+            conflicting = [
+                name
+                for name in ("PRIVATE_KEY", "MNEMONIC", "MNEMONIC_FILE")
+                if os.getenv(p + name)
+            ]
+            if conflicting:
+                raise ValueError(
+                    f"FORGE_API_KEY and FORGE_SIGNING_WALLET_ID are set alongside "
+                    f"{conflicting}; choose exactly one signing source"
+                )
+
             from .remote_signer import make_remote_wallet
 
             backend_url = os.getenv(p + "FORGE_BACKEND_URL", "https://forge.allora.network")

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -93,10 +93,10 @@ class AlloraWalletConfig:
             # downstream code uses the wallet directly, so `prefix` would otherwise be a
             # silently-ignored, possibly-misleading value. Align it to the wallet's actual
             # prefix (e.g. a RemoteWallet built with prefix="cosmos").
-            try:
-                hrp = str(self.wallet.address()).split("1", 1)[0]
-            except Exception:
-                hrp = ""
+            # No try/except: only wallet.address() can raise here, and a Wallet whose
+            # address() raises is a real bug that should surface, not be swallowed into a
+            # silently wrong prefix that fails far downstream in the broadcast path.
+            hrp = str(self.wallet.address()).split("1", 1)[0]
             if hrp:
                 self.prefix = hrp
 

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -28,11 +28,27 @@ class AlloraWalletConfig:
 
     @classmethod
     def from_env(cls, env_prefix: str | None = None) -> 'AlloraWalletConfig':
+        p = env_prefix or ""
+        prefix = os.getenv(p + "ADDRESS_PREFIX", "allo")
+
+        # Privy-delegated signing: if the Forge env vars are present, build a RemoteWallet
+        # so 12-factor deployments can use delegated signing without hand-written wiring.
+        # Note: this performs a blocking wallet-info fetch; async callers that need to avoid
+        # it can build the wallet via make_remote_wallet(..., public_key_hex=...) directly.
+        api_key = os.getenv(p + "FORGE_API_KEY")
+        wallet_id = os.getenv(p + "FORGE_SIGNING_WALLET_ID")
+        if api_key and wallet_id:
+            from .remote_signer import make_remote_wallet
+
+            backend_url = os.getenv(p + "FORGE_BACKEND_URL", "https://forge.allora.network")
+            wallet = make_remote_wallet(backend_url, api_key, wallet_id, prefix=prefix)
+            return cls(wallet=wallet, prefix=prefix)
+
         return cls(
-            private_key=os.getenv((env_prefix or "") + "PRIVATE_KEY"),
-            mnemonic=os.getenv((env_prefix or "") + "MNEMONIC"),
-            mnemonic_file=os.getenv((env_prefix or "") + "MNEMONIC_FILE"),
-            prefix=os.getenv((env_prefix or "") + "ADDRESS_PREFIX", "allo"),
+            private_key=os.getenv(p + "PRIVATE_KEY"),
+            mnemonic=os.getenv(p + "MNEMONIC"),
+            mnemonic_file=os.getenv(p + "MNEMONIC_FILE"),
+            prefix=prefix,
         )
 
     def __post_init__(self):

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 from cosmpy.aerial.config import NetworkConfig
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 
 
 @dataclass
@@ -14,14 +14,16 @@ class AlloraWalletConfig:
     - private_key: Hex-encoded private key string.
     - mnemonic: Mnemonic phrase string.
     - mnemonic_file: Path to a file containing the mnemonic phrase.
-    - wallet: An existing LocalWallet instance.
+    - wallet: An existing cosmpy Wallet instance (e.g. a LocalWallet for self-managed
+      signing, or a RemoteWallet from make_remote_wallet() for Privy-managed signing
+      delegated to the Forge backend).
 
     The address prefix can also be specified (default is "allo").
     """
     private_key: Optional[str] = None
     mnemonic: Optional[str] = None
     mnemonic_file: Optional[str] = None
-    wallet: Optional[LocalWallet] = None
+    wallet: Optional[Wallet] = None
     prefix: str = "allo"
 
     @classmethod

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -36,13 +36,18 @@ class AlloraWalletConfig:
         )
 
     def __post_init__(self):
-        if (
-            self.private_key is None and
-            self.mnemonic is None and
-            self.mnemonic_file is None and
-            self.wallet is None
-        ):
+        sources = sum(
+            x is not None
+            for x in (self.private_key, self.mnemonic, self.mnemonic_file, self.wallet)
+        )
+        if sources == 0:
             raise ValueError("No wallet credentials provided")
+        if sources > 1:
+            # Avoid a silent-precedence footgun (e.g. leaving PRIVATE_KEY set while
+            # adding wallet=). Require an unambiguous single credential source.
+            raise ValueError(
+                "Exactly one of private_key, mnemonic, mnemonic_file, or wallet must be provided"
+            )
 
 
 @dataclass

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -358,6 +358,8 @@ def make_remote_wallet(
     wallet_id: str,
     prefix: str = "allo",
     timeout: float = DEFAULT_TIMEOUT,
+    public_key_hex: Optional[str] = None,
+    address: Optional[str] = None,
     client: Optional[ForgeBackendClient] = None,
 ) -> RemoteWallet:
     """Construct a backend-backed wallet for the Privy-managed signing path.
@@ -366,7 +368,20 @@ def make_remote_wallet(
     wallet config) to sign through the Forge backend instead of a local key. Inject a
     custom ``client`` (e.g. with a tuned :class:`requests.Session`) to control the HTTP
     transport.
+
+    Pass ``public_key_hex`` to skip the blocking wallet-info fetch (useful in async
+    contexts such as FastAPI startup or async test fixtures). When you do, also pass
+    ``address`` to keep the local pubkey↔address cross-check; note the backend is not
+    contacted until the first signing call, so the ``(api_key, wallet_id)`` binding is
+    not validated at construction time.
     """
     return RemoteWallet(
-        backend_url, api_key, wallet_id, prefix=prefix, timeout=timeout, client=client
+        backend_url,
+        api_key,
+        wallet_id,
+        prefix=prefix,
+        timeout=timeout,
+        public_key_hex=public_key_hex,
+        address=address,
+        client=client,
     )

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -31,6 +31,9 @@ from cosmpy.crypto.keypairs import PublicKey
 
 API_KEY_HEADER = "X-Forge-API-Key"
 DEFAULT_TIMEOUT = 30.0
+# Legitimate responses (hex signature + pubkey, wallet-info object) are well under 1 KiB.
+# Cap reads so a misbehaving or hostile backend cannot drive the worker to OOM.
+MAX_RESPONSE_BYTES = 64 * 1024
 
 
 class RemoteSignerError(Exception):
@@ -140,6 +143,7 @@ class ForgeBackendClient:
             # Never follow redirects: requests re-sends the X-Forge-API-Key header on
             # cross-host 3xx, so a redirecting/compromised backend could exfiltrate the
             # key (which authorizes delegated signing). Treat any 3xx as an error below.
+            # stream=True so the body is read with an explicit size cap (see below).
             resp = self._session.request(
                 method,
                 self._base + path,
@@ -147,13 +151,23 @@ class ForgeBackendClient:
                 headers=headers,
                 timeout=self._timeout,
                 allow_redirects=False,
+                stream=True,
             )
         except requests.RequestException as e:
             raise ForgeBackendError(f"failed to reach forge backend: {e}") from e
 
+        with resp:
+            raw = resp.raw.read(MAX_RESPONSE_BYTES + 1, decode_content=True)
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raise ForgeBackendError(
+                f"forge backend response exceeded {MAX_RESPONSE_BYTES} bytes"
+            )
+
         if not (200 <= resp.status_code < 300):
-            raise ForgeBackendError(f"forge backend returned {resp.status_code}: {resp.text}")
-        return resp.json()
+            raise ForgeBackendError(
+                f"forge backend returned {resp.status_code}: {raw.decode(errors='replace')}"
+            )
+        return json.loads(raw.decode())
 
 
 class RemoteSigner(Signer):

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -19,10 +19,9 @@ Usage::
 """
 
 import json
-import urllib.error
-import urllib.request
-from typing import Optional
+from typing import Any, Optional
 
+import requests
 from cosmpy.aerial.wallet import Wallet
 from cosmpy.crypto.address import Address
 from cosmpy.crypto.interface import Signer
@@ -46,6 +45,60 @@ class WalletConfigError(RemoteSignerError):
     not match the public key, or required fields are inconsistent)."""
 
 
+class ForgeBackendClient:
+    """HTTP transport for the Forge signing-wallet API.
+
+    Owns a single :class:`requests.Session` so connections to the backend are reused
+    across wallet-info and signing calls. Inject a custom ``session`` to install a CA
+    bundle, retry policy, or a stub transport in tests. All errors surface as
+    :class:`ForgeBackendError`.
+    """
+
+    def __init__(
+        self,
+        backend_url: str,
+        api_key: str,
+        timeout: float = DEFAULT_TIMEOUT,
+        session: Optional[requests.Session] = None,
+    ):
+        self._base = backend_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        self._session = session if session is not None else requests.Session()
+
+    def get_wallet_info(self, wallet_id: str) -> dict[str, Any]:
+        """Fetch a signing wallet's public, non-secret info (id, address, pubkey)."""
+        return self._request("GET", f"/api/v1/signing-wallets/{wallet_id}")
+
+    def sign(self, wallet_id: str, payload: bytes, prehashed: bool) -> dict[str, Any]:
+        """Delegate signing of ``payload`` to the backend.
+
+        When ``prehashed`` is False the backend SHA-256 hashes the payload (Cosmos
+        SignDoc); when True it signs the 32-byte digest as-is.
+        """
+        body = json.dumps({"payload": payload.hex(), "prehashed": prehashed})
+        return self._request("POST", f"/api/v1/signing-wallets/{wallet_id}/sign", body)
+
+    def _request(self, method: str, path: str, body: Optional[str] = None) -> dict[str, Any]:
+        headers = {API_KEY_HEADER: self._api_key}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        try:
+            resp = self._session.request(
+                method,
+                self._base + path,
+                data=body,
+                headers=headers,
+                timeout=self._timeout,
+            )
+        except requests.RequestException as e:
+            raise ForgeBackendError(f"failed to reach forge backend: {e}") from e
+
+        if not (200 <= resp.status_code < 300):
+            raise ForgeBackendError(f"forge backend returned {resp.status_code}: {resp.text}")
+        return resp.json()
+
+
 class RemoteSigner(Signer):
     """A cosmpy Signer that delegates signing to the Forge backend.
 
@@ -57,11 +110,9 @@ class RemoteSigner(Signer):
     The private key never leaves Privy/the backend.
     """
 
-    def __init__(self, backend_url: str, api_key: str, wallet_id: str, timeout: float = DEFAULT_TIMEOUT):
-        self._base = backend_url.rstrip("/")
-        self._api_key = api_key
+    def __init__(self, client: ForgeBackendClient, wallet_id: str):
+        self._client = client
         self._wallet_id = wallet_id
-        self._timeout = timeout
 
     def sign(self, message: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
         # The backend hashes the message (SHA-256) before signing, matching cosmpy's
@@ -73,9 +124,7 @@ class RemoteSigner(Signer):
         return self._remote_sign(digest, prehashed=True)
 
     def _remote_sign(self, payload: bytes, prehashed: bool) -> bytes:
-        url = f"{self._base}/api/v1/signing-wallets/{self._wallet_id}/sign"
-        body = json.dumps({"payload": payload.hex(), "prehashed": prehashed}).encode()
-        data = _post_json(url, body, self._api_key, self._timeout)
+        data = self._client.sign(self._wallet_id, payload, prehashed)
         signature = data.get("signature")
         if not signature:
             raise ForgeBackendError("forge sign response missing 'signature'")
@@ -98,16 +147,16 @@ class RemoteWallet(Wallet):
         prefix: str = "allo",
         timeout: float = DEFAULT_TIMEOUT,
         public_key_hex: Optional[str] = None,
+        client: Optional[ForgeBackendClient] = None,
     ):
-        self._base = backend_url.rstrip("/")
-        self._api_key = api_key
         self._wallet_id = wallet_id
         self._prefix = prefix
-        self._signer = RemoteSigner(backend_url, api_key, wallet_id, timeout)
+        self._client = client if client is not None else ForgeBackendClient(backend_url, api_key, timeout)
+        self._signer = RemoteSigner(self._client, wallet_id)
 
         reported_address: Optional[str] = None
         if public_key_hex is None:
-            info = self._fetch_info(timeout)
+            info = self._client.get_wallet_info(wallet_id)
             public_key_hex = info.get("pubkey")
             reported_address = info.get("address")
             if not public_key_hex:
@@ -122,10 +171,6 @@ class RemoteWallet(Wallet):
             raise WalletConfigError(
                 f"backend address {reported_address} does not match pubkey-derived address {derived}"
             )
-
-    def _fetch_info(self, timeout: float) -> dict:
-        url = f"{self._base}/api/v1/signing-wallets/{self._wallet_id}"
-        return _get_json(url, self._api_key, timeout)
 
     def address(self) -> Address:
         return Address(self._public_key, self._prefix)
@@ -143,34 +188,15 @@ def make_remote_wallet(
     wallet_id: str,
     prefix: str = "allo",
     timeout: float = DEFAULT_TIMEOUT,
+    client: Optional[ForgeBackendClient] = None,
 ) -> RemoteWallet:
     """Construct a backend-backed wallet for the Privy-managed signing path.
 
     Pass the result to ``AlloraWalletConfig(wallet=...)`` (or ``AlloraWorker`` via its
-    wallet config) to sign through the Forge backend instead of a local key.
+    wallet config) to sign through the Forge backend instead of a local key. Inject a
+    custom ``client`` (e.g. with a tuned :class:`requests.Session`) to control the HTTP
+    transport.
     """
-    return RemoteWallet(backend_url, api_key, wallet_id, prefix=prefix, timeout=timeout)
-
-
-def _get_json(url: str, api_key: str, timeout: float) -> dict:
-    req = urllib.request.Request(url, method="GET")
-    req.add_header(API_KEY_HEADER, api_key)
-    return _do(req, timeout)
-
-
-def _post_json(url: str, body: bytes, api_key: str, timeout: float) -> dict:
-    req = urllib.request.Request(url, data=body, method="POST")
-    req.add_header("Content-Type", "application/json")
-    req.add_header(API_KEY_HEADER, api_key)
-    return _do(req, timeout)
-
-
-def _do(req: urllib.request.Request, timeout: float) -> dict:
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as e:
-        detail = e.read().decode(errors="replace")
-        raise ForgeBackendError(f"forge backend returned {e.code}: {detail}") from e
-    except urllib.error.URLError as e:
-        raise ForgeBackendError(f"failed to reach forge backend: {e.reason}") from e
+    return RemoteWallet(
+        backend_url, api_key, wallet_id, prefix=prefix, timeout=timeout, client=client
+    )

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -209,11 +209,25 @@ class RemoteSigner(Signer):
     def sign(self, message: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
         # The backend hashes the message (SHA-256) before signing, matching cosmpy's
         # local PrivateKey.sign semantics over the SignDoc bytes.
+        self._check_canonicalise(canonicalise)
         return self._remote_sign(message, prehashed=False)
 
     def sign_digest(self, digest: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
         # The digest is already hashed; the backend signs it directly.
+        self._check_canonicalise(canonicalise)
         return self._remote_sign(digest, prehashed=True)
+
+    @staticmethod
+    def _check_canonicalise(canonicalise: bool) -> None:
+        # The backend always returns a canonical (low-S) signature; we cannot honor a
+        # request for a non-canonical one, so reject it rather than silently lie about
+        # the encoding. (deterministic is always RFC 6979 on the backend, which is a
+        # valid signature regardless of the requested value, so it is not rejected.)
+        if not canonicalise:
+            raise ValueError(
+                "RemoteSigner only produces canonical (low-S) signatures; "
+                "canonicalise=False is not supported"
+            )
 
     def _remote_sign(self, payload: bytes, prehashed: bool) -> bytes:
         result = self._client.sign(self._wallet_id, payload, prehashed)

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -32,6 +32,20 @@ API_KEY_HEADER = "X-Forge-API-Key"
 DEFAULT_TIMEOUT = 30.0
 
 
+class RemoteSignerError(Exception):
+    """Base exception for Privy-delegated (remote) signing errors."""
+
+
+class ForgeBackendError(RemoteSignerError):
+    """The Forge backend returned an HTTP error, was unreachable, or sent a
+    malformed/unexpected response."""
+
+
+class WalletConfigError(RemoteSignerError):
+    """The remote wallet is misconfigured (e.g. the backend-reported address does
+    not match the public key, or required fields are inconsistent)."""
+
+
 class RemoteSigner(Signer):
     """A cosmpy Signer that delegates signing to the Forge backend.
 
@@ -64,7 +78,7 @@ class RemoteSigner(Signer):
         data = _post_json(url, body, self._api_key, self._timeout)
         signature = data.get("signature")
         if not signature:
-            raise RuntimeError("forge sign response missing 'signature'")
+            raise ForgeBackendError("forge sign response missing 'signature'")
         return bytes.fromhex(signature)
 
 
@@ -97,7 +111,7 @@ class RemoteWallet(Wallet):
             public_key_hex = info.get("pubkey")
             reported_address = info.get("address")
             if not public_key_hex:
-                raise RuntimeError("forge wallet-info response missing 'pubkey'")
+                raise ForgeBackendError("forge wallet-info response missing 'pubkey'")
 
         self._public_key = PublicKey(bytes.fromhex(public_key_hex))
 
@@ -105,7 +119,7 @@ class RemoteWallet(Wallet):
         # misconfigured wallet fails here rather than producing rejected transactions.
         derived = str(Address(self._public_key, self._prefix))
         if reported_address and reported_address != derived:
-            raise RuntimeError(
+            raise WalletConfigError(
                 f"backend address {reported_address} does not match pubkey-derived address {derived}"
             )
 
@@ -157,6 +171,6 @@ def _do(req: urllib.request.Request, timeout: float) -> dict:
             return json.loads(resp.read().decode())
     except urllib.error.HTTPError as e:
         detail = e.read().decode(errors="replace")
-        raise RuntimeError(f"forge backend returned {e.code}: {detail}") from e
+        raise ForgeBackendError(f"forge backend returned {e.code}: {detail}") from e
     except urllib.error.URLError as e:
-        raise RuntimeError(f"failed to reach forge backend: {e.reason}") from e
+        raise ForgeBackendError(f"failed to reach forge backend: {e.reason}") from e

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -219,7 +219,17 @@ class RemoteSigner(Signer):
         result = self._client.sign(self._wallet_id, payload, prehashed)
         if not result.signature:
             raise ForgeBackendError("forge sign response missing 'signature'")
-        sig = bytes.fromhex(result.signature)
+        try:
+            sig = bytes.fromhex(result.signature)
+        except ValueError as e:
+            raise ForgeBackendError(f"forge sign response 'signature' is not valid hex: {e}") from e
+        if len(sig) != 64:
+            # Cosmos secp256k1 signatures are exactly 64 raw bytes (r || s). A 65-byte
+            # recoverable form or DER encoding would be rejected on-chain with an opaque
+            # error, so fail fast here instead.
+            raise ForgeBackendError(
+                f"forge sign response signature has wrong length {len(sig)} (expected 64)"
+            )
         self._verify(payload, sig, prehashed, result.pubkey)
         return sig
 

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -117,7 +117,8 @@ class ForgeBackendClient:
 
     def get_wallet_info(self, wallet_id: str) -> SigningWalletInfo:
         """Fetch a signing wallet's public, non-secret info (id, address, pubkey)."""
-        raw = self._request("GET", f"/api/v1/signing-wallets/{wallet_id}")
+        wid = urllib.parse.quote(wallet_id, safe="")
+        raw = self._request("GET", f"/api/v1/signing-wallets/{wid}")
         return _validate(SigningWalletInfo, raw, "wallet-info")
 
     def sign(self, wallet_id: str, payload: bytes, prehashed: bool) -> SignResult:
@@ -126,8 +127,9 @@ class ForgeBackendClient:
         When ``prehashed`` is False the backend SHA-256 hashes the payload (Cosmos
         SignDoc); when True it signs the 32-byte digest as-is.
         """
+        wid = urllib.parse.quote(wallet_id, safe="")
         body = json.dumps({"payload": payload.hex(), "prehashed": prehashed})
-        raw = self._request("POST", f"/api/v1/signing-wallets/{wallet_id}/sign", body)
+        raw = self._request("POST", f"/api/v1/signing-wallets/{wid}/sign", body)
         return _validate(SignResult, raw, "sign")
 
     def _request(self, method: str, path: str, body: Optional[str] = None) -> dict[str, Any]:

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -164,9 +164,10 @@ class ForgeBackendClient:
             )
 
         if not (200 <= resp.status_code < 300):
-            raise ForgeBackendError(
-                f"forge backend returned {resp.status_code}: {raw.decode(errors='replace')}"
-            )
+            # Truncate: backend 4xx bodies can reflect request fields / wallet ids, and
+            # this message bubbles up to operator logs.
+            detail = raw.decode(errors="replace")[:512]
+            raise ForgeBackendError(f"forge backend returned {resp.status_code}: {detail}")
 
         try:
             parsed = json.loads(raw.decode())

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -300,6 +300,10 @@ class RemoteWallet(Wallet):
             reported_address = info.address
             if not public_key_hex:
                 raise ForgeBackendError("forge wallet-info response missing 'pubkey'")
+            # Fail closed: an empty address would otherwise skip the cross-check below,
+            # leaving the (api_key, wallet_id) <-> keypair binding unverified.
+            if not reported_address:
+                raise ForgeBackendError("forge wallet-info response missing 'address'")
 
         try:
             pubkey_bytes = bytes.fromhex(public_key_hex)

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -20,6 +20,7 @@ Usage::
 
 import json
 import urllib.parse
+import uuid
 from typing import Any, Optional, TypeVar
 
 import requests
@@ -314,6 +315,15 @@ class RemoteWallet(Wallet):
         address: Optional[str] = None,
         client: Optional[ForgeBackendClient] = None,
     ):
+        # forge-v2 keys signing wallets by Privy UUID, so a non-UUID wallet_id is always a
+        # config bug (e.g. a typo in FORGE_SIGNING_WALLET_ID). Fail locally with a clear error
+        # rather than as an opaque 404 on the first request (parity with allora-sdk-go's
+        # uuid.Parse guard).
+        try:
+            uuid.UUID(wallet_id)
+        except ValueError as e:
+            raise WalletConfigError(f"wallet_id must be a UUID, got {wallet_id!r}: {e}") from e
+
         self._wallet_id = wallet_id
         self._prefix = prefix
         self._client = client if client is not None else ForgeBackendClient(backend_url, api_key, timeout)

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -301,7 +301,17 @@ class RemoteWallet(Wallet):
             if not public_key_hex:
                 raise ForgeBackendError("forge wallet-info response missing 'pubkey'")
 
-        self._public_key = PublicKey(bytes.fromhex(public_key_hex))
+        try:
+            pubkey_bytes = bytes.fromhex(public_key_hex)
+        except ValueError as e:
+            raise WalletConfigError(f"wallet pubkey is not valid hex: {e}") from e
+        if len(pubkey_bytes) != 33:
+            # Cosmos secp256k1 pubkeys are 33-byte compressed; surface a clear error
+            # rather than an obscure ecdsa failure deep inside cosmpy.
+            raise WalletConfigError(
+                f"expected 33-byte compressed secp256k1 pubkey, got {len(pubkey_bytes)} bytes"
+            )
+        self._public_key = PublicKey(pubkey_bytes)
 
         # Cross-check the backend's reported address against the pubkey-derived one so a
         # misconfigured wallet fails here rather than producing rejected transactions.

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -230,6 +230,10 @@ class RemoteSigner(Signer):
             )
 
     def _remote_sign(self, payload: bytes, prehashed: bool) -> bytes:
+        if not payload:
+            # The backend binds `payload` with gin's `binding:"required"`, which treats
+            # an empty string as missing and returns a 400; fail locally with a clear error.
+            raise ValueError("cannot sign an empty payload")
         result = self._client.sign(self._wallet_id, payload, prehashed)
         if not result.signature:
             raise ForgeBackendError("forge sign response missing 'signature'")

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -198,12 +198,13 @@ class RemoteSigner(Signer):
         self,
         client: ForgeBackendClient,
         wallet_id: str,
-        public_key: Optional[PublicKey] = None,
+        public_key: PublicKey,
     ):
         self._client = client
         self._wallet_id = wallet_id
-        # When known, the wallet pubkey is used to verify every returned signature
-        # locally so a backend bug or MITM cannot make the worker broadcast garbage.
+        # The wallet pubkey verifies every returned signature locally so a backend bug or
+        # MITM cannot make the worker broadcast garbage. Required (not optional) so a signer
+        # constructed directly can never silently skip verification; RemoteWallet supplies it.
         self._public_key = public_key
 
     def sign(self, message: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
@@ -253,8 +254,6 @@ class RemoteSigner(Signer):
 
     def _verify(self, payload: bytes, sig: bytes, prehashed: bool, response_pubkey: Optional[str]) -> None:
         """Verify the backend's signature against the pinned wallet public key."""
-        if self._public_key is None:
-            return
         expected = self._public_key.public_key_bytes.hex()
         if response_pubkey and response_pubkey != expected:
             raise WalletConfigError(

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -277,6 +277,13 @@ class RemoteWallet(Wallet):
     The public key and address are fetched from the backend on construction (or supplied
     directly) so the wallet can seal/simulate transactions before it has ever transacted
     on-chain. ``signer()`` returns a :class:`RemoteSigner`.
+
+    Passing ``public_key_hex`` skips the (blocking) wallet-info fetch — useful from async
+    contexts. **When you use it, the backend is not contacted at construction, so the
+    (api_key, wallet_id) binding and the wallet's existence are NOT verified until the
+    first ``sign`` call.** Pass ``address`` alongside ``public_key_hex`` to keep the local
+    pubkey↔address cross-check; a wrong ``wallet_id`` will then only surface as a 404/403
+    on the first signing request.
     """
 
     def __init__(
@@ -287,13 +294,15 @@ class RemoteWallet(Wallet):
         prefix: str = "allo",
         timeout: float = DEFAULT_TIMEOUT,
         public_key_hex: Optional[str] = None,
+        address: Optional[str] = None,
         client: Optional[ForgeBackendClient] = None,
     ):
         self._wallet_id = wallet_id
         self._prefix = prefix
         self._client = client if client is not None else ForgeBackendClient(backend_url, api_key, timeout)
 
-        reported_address: Optional[str] = None
+        # For the public_key_hex shortcut, cross-check against a caller-supplied address.
+        reported_address: Optional[str] = address
         if public_key_hex is None:
             info = self._client.get_wallet_info(wallet_id)
             # Guard against a proxy misroute / cache bug returning a different wallet.

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -19,9 +19,10 @@ Usage::
 """
 
 import json
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 import requests
+from pydantic import BaseModel, ValidationError
 from cosmpy.aerial.wallet import Wallet
 from cosmpy.crypto.address import Address
 from cosmpy.crypto.interface import Signer
@@ -45,6 +46,35 @@ class WalletConfigError(RemoteSignerError):
     not match the public key, or required fields are inconsistent)."""
 
 
+class SigningWalletInfo(BaseModel):
+    """Non-secret view of a Forge signing wallet, as returned by the backend.
+
+    The wire shape is a cross-repo HTTP contract shared with allora-sdk-go,
+    allora-sdk-ts, and forge-v2.
+    """
+
+    id: str
+    address: str
+    pubkey: str  # hex-encoded 33-byte compressed secp256k1 public key
+
+
+class SignResult(BaseModel):
+    """A signature produced by the Forge backend."""
+
+    signature: str  # hex-encoded 64-byte canonical (low-S) secp256k1 signature
+    pubkey: Optional[str] = None
+
+
+_M = TypeVar("_M", bound=BaseModel)
+
+
+def _validate(model: type[_M], raw: dict[str, Any], what: str) -> _M:
+    try:
+        return model.model_validate(raw)
+    except ValidationError as e:
+        raise ForgeBackendError(f"unexpected forge {what} response: {e}") from e
+
+
 class ForgeBackendClient:
     """HTTP transport for the Forge signing-wallet API.
 
@@ -66,18 +96,20 @@ class ForgeBackendClient:
         self._timeout = timeout
         self._session = session if session is not None else requests.Session()
 
-    def get_wallet_info(self, wallet_id: str) -> dict[str, Any]:
+    def get_wallet_info(self, wallet_id: str) -> SigningWalletInfo:
         """Fetch a signing wallet's public, non-secret info (id, address, pubkey)."""
-        return self._request("GET", f"/api/v1/signing-wallets/{wallet_id}")
+        raw = self._request("GET", f"/api/v1/signing-wallets/{wallet_id}")
+        return _validate(SigningWalletInfo, raw, "wallet-info")
 
-    def sign(self, wallet_id: str, payload: bytes, prehashed: bool) -> dict[str, Any]:
+    def sign(self, wallet_id: str, payload: bytes, prehashed: bool) -> SignResult:
         """Delegate signing of ``payload`` to the backend.
 
         When ``prehashed`` is False the backend SHA-256 hashes the payload (Cosmos
         SignDoc); when True it signs the 32-byte digest as-is.
         """
         body = json.dumps({"payload": payload.hex(), "prehashed": prehashed})
-        return self._request("POST", f"/api/v1/signing-wallets/{wallet_id}/sign", body)
+        raw = self._request("POST", f"/api/v1/signing-wallets/{wallet_id}/sign", body)
+        return _validate(SignResult, raw, "sign")
 
     def _request(self, method: str, path: str, body: Optional[str] = None) -> dict[str, Any]:
         headers = {API_KEY_HEADER: self._api_key}
@@ -124,11 +156,10 @@ class RemoteSigner(Signer):
         return self._remote_sign(digest, prehashed=True)
 
     def _remote_sign(self, payload: bytes, prehashed: bool) -> bytes:
-        data = self._client.sign(self._wallet_id, payload, prehashed)
-        signature = data.get("signature")
-        if not signature:
+        result = self._client.sign(self._wallet_id, payload, prehashed)
+        if not result.signature:
             raise ForgeBackendError("forge sign response missing 'signature'")
-        return bytes.fromhex(signature)
+        return bytes.fromhex(result.signature)
 
 
 class RemoteWallet(Wallet):
@@ -157,8 +188,8 @@ class RemoteWallet(Wallet):
         reported_address: Optional[str] = None
         if public_key_hex is None:
             info = self._client.get_wallet_info(wallet_id)
-            public_key_hex = info.get("pubkey")
-            reported_address = info.get("address")
+            public_key_hex = info.pubkey
+            reported_address = info.address
             if not public_key_hex:
                 raise ForgeBackendError("forge wallet-info response missing 'pubkey'")
 

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -296,6 +296,11 @@ class RemoteWallet(Wallet):
         reported_address: Optional[str] = None
         if public_key_hex is None:
             info = self._client.get_wallet_info(wallet_id)
+            # Guard against a proxy misroute / cache bug returning a different wallet.
+            if info.id and info.id != wallet_id:
+                raise WalletConfigError(
+                    f"forge wallet-info id {info.id} does not match requested wallet_id {wallet_id}"
+                )
             public_key_hex = info.pubkey
             reported_address = info.address
             if not public_key_hex:

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -167,7 +167,19 @@ class ForgeBackendClient:
             raise ForgeBackendError(
                 f"forge backend returned {resp.status_code}: {raw.decode(errors='replace')}"
             )
-        return json.loads(raw.decode())
+
+        try:
+            parsed = json.loads(raw.decode())
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            snippet = raw.decode(errors="replace")[:256]
+            raise ForgeBackendError(
+                f"forge backend returned non-JSON response: {snippet!r}"
+            ) from e
+        if not isinstance(parsed, dict):
+            raise ForgeBackendError(
+                f"forge backend returned non-object JSON ({type(parsed).__name__})"
+            )
+        return parsed
 
 
 class RemoteSigner(Signer):

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -54,12 +54,20 @@ class SigningWalletInfo(BaseModel):
     """Non-secret view of a Forge signing wallet, as returned by the backend.
 
     The wire shape is a cross-repo HTTP contract shared with allora-sdk-go,
-    allora-sdk-ts, and forge-v2.
+    allora-sdk-ts, and forge-v2. ``id``/``address``/``pubkey`` are required; the
+    remaining fields are optional metadata forge-v2 returns. They are modeled
+    explicitly (rather than silently dropped) so the contract is documented here.
+    Unknown future fields are still ignored — a lenient client, matching
+    allora-sdk-go's response struct.
     """
 
     id: str
     address: str
     pubkey: str  # hex-encoded 33-byte compressed secp256k1 public key
+    evm_address: Optional[str] = None  # 0x... Privy-reported EVM address (cross-check/debug)
+    privy_wallet_id: Optional[str] = None  # Privy server wallet id
+    label: Optional[str] = None
+    created_at: Optional[str] = None  # RFC 3339 timestamp; kept as a raw string (unused locally)
 
 
 class SignResult(BaseModel):

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -116,12 +116,16 @@ class ForgeBackendClient:
         if body is not None:
             headers["Content-Type"] = "application/json"
         try:
+            # Never follow redirects: requests re-sends the X-Forge-API-Key header on
+            # cross-host 3xx, so a redirecting/compromised backend could exfiltrate the
+            # key (which authorizes delegated signing). Treat any 3xx as an error below.
             resp = self._session.request(
                 method,
                 self._base + path,
                 data=body,
                 headers=headers,
                 timeout=self._timeout,
+                allow_redirects=False,
             )
         except requests.RequestException as e:
             raise ForgeBackendError(f"failed to reach forge backend: {e}") from e

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -19,6 +19,7 @@ Usage::
 """
 
 import json
+import urllib.parse
 from typing import Any, Optional, TypeVar
 
 import requests
@@ -75,6 +76,23 @@ def _validate(model: type[_M], raw: dict[str, Any], what: str) -> _M:
         raise ForgeBackendError(f"unexpected forge {what} response: {e}") from e
 
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _validate_backend_url(url: str) -> None:
+    """Require https:// for the Forge backend so the long-lived API key is never sent
+    in cleartext. Plain http:// is permitted only for loopback (local development)."""
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme == "https":
+        return
+    if parsed.scheme == "http" and parsed.hostname in _LOOPBACK_HOSTS:
+        return
+    raise ValueError(
+        f"backend_url must use https:// (got {parsed.scheme or 'no'} scheme); "
+        "http:// is only allowed for loopback hosts in local development"
+    )
+
+
 class ForgeBackendClient:
     """HTTP transport for the Forge signing-wallet API.
 
@@ -91,6 +109,7 @@ class ForgeBackendClient:
         timeout: float = DEFAULT_TIMEOUT,
         session: Optional[requests.Session] = None,
     ):
+        _validate_backend_url(backend_url)
         self._base = backend_url.rstrip("/")
         self._api_key = api_key
         self._timeout = timeout

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -254,11 +254,21 @@ class RemoteSigner(Signer):
 
     def _verify(self, payload: bytes, sig: bytes, prehashed: bool, response_pubkey: Optional[str]) -> None:
         """Verify the backend's signature against the pinned wallet public key."""
-        expected = self._public_key.public_key_bytes.hex()
-        if response_pubkey and response_pubkey != expected:
-            raise WalletConfigError(
-                "forge sign response pubkey does not match the wallet public key"
-            )
+        # Compare decoded bytes, not hex strings: bytes.hex() is lowercase but a future
+        # backend / proxy could return uppercase hex for an otherwise-valid signature.
+        # (Go decodes both sides to bytes; allora-sdk-ts lower-cases defensively.)
+        expected = self._public_key.public_key_bytes
+        if response_pubkey:
+            try:
+                resp_bytes = bytes.fromhex(response_pubkey)
+            except ValueError as e:
+                raise ForgeBackendError(
+                    f"forge sign response pubkey is not valid hex: {e}"
+                ) from e
+            if resp_bytes != expected:
+                raise WalletConfigError(
+                    "forge sign response pubkey does not match the wallet public key"
+                )
         verified = (
             self._public_key.verify_digest(payload, sig)
             if prehashed

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -194,9 +194,17 @@ class RemoteSigner(Signer):
     The private key never leaves Privy/the backend.
     """
 
-    def __init__(self, client: ForgeBackendClient, wallet_id: str):
+    def __init__(
+        self,
+        client: ForgeBackendClient,
+        wallet_id: str,
+        public_key: Optional[PublicKey] = None,
+    ):
         self._client = client
         self._wallet_id = wallet_id
+        # When known, the wallet pubkey is used to verify every returned signature
+        # locally so a backend bug or MITM cannot make the worker broadcast garbage.
+        self._public_key = public_key
 
     def sign(self, message: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
         # The backend hashes the message (SHA-256) before signing, matching cosmpy's
@@ -211,7 +219,28 @@ class RemoteSigner(Signer):
         result = self._client.sign(self._wallet_id, payload, prehashed)
         if not result.signature:
             raise ForgeBackendError("forge sign response missing 'signature'")
-        return bytes.fromhex(result.signature)
+        sig = bytes.fromhex(result.signature)
+        self._verify(payload, sig, prehashed, result.pubkey)
+        return sig
+
+    def _verify(self, payload: bytes, sig: bytes, prehashed: bool, response_pubkey: Optional[str]) -> None:
+        """Verify the backend's signature against the pinned wallet public key."""
+        if self._public_key is None:
+            return
+        expected = self._public_key.public_key_bytes.hex()
+        if response_pubkey and response_pubkey != expected:
+            raise WalletConfigError(
+                "forge sign response pubkey does not match the wallet public key"
+            )
+        verified = (
+            self._public_key.verify_digest(payload, sig)
+            if prehashed
+            else self._public_key.verify(payload, sig)
+        )
+        if not verified:
+            raise ForgeBackendError(
+                "forge backend returned a signature that does not verify against the wallet public key"
+            )
 
 
 class RemoteWallet(Wallet):
@@ -235,7 +264,6 @@ class RemoteWallet(Wallet):
         self._wallet_id = wallet_id
         self._prefix = prefix
         self._client = client if client is not None else ForgeBackendClient(backend_url, api_key, timeout)
-        self._signer = RemoteSigner(self._client, wallet_id)
 
         reported_address: Optional[str] = None
         if public_key_hex is None:
@@ -254,6 +282,9 @@ class RemoteWallet(Wallet):
             raise WalletConfigError(
                 f"backend address {reported_address} does not match pubkey-derived address {derived}"
             )
+
+        # Pin the pubkey into the signer so it verifies every backend signature locally.
+        self._signer = RemoteSigner(self._client, wallet_id, public_key=self._public_key)
 
     def address(self) -> Address:
         return Address(self._public_key, self._prefix)

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -1,0 +1,162 @@
+"""
+Privy-managed (delegated) signing for the Allora SDK.
+
+These types let a worker sign without holding a private key: signing is delegated to
+the Forge backend, which signs with a Privy server wallet. They implement cosmpy's
+``Signer`` and ``Wallet`` interfaces, so they drop straight into the existing tx and
+bundle signing paths (``TxManager`` and ``EmissionsClient``) with no other changes.
+
+Usage::
+
+    from allora_sdk import make_remote_wallet, AlloraWalletConfig, AlloraRPCClient
+
+    wallet = make_remote_wallet(
+        backend_url="https://forge.allora.network",
+        api_key="forge_sk_...",
+        wallet_id="<signing-wallet-uuid>",
+    )
+    client = AlloraRPCClient(wallet=AlloraWalletConfig(wallet=wallet), ...)
+"""
+
+import json
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from cosmpy.aerial.wallet import Wallet
+from cosmpy.crypto.address import Address
+from cosmpy.crypto.interface import Signer
+from cosmpy.crypto.keypairs import PublicKey
+
+API_KEY_HEADER = "X-Forge-API-Key"
+DEFAULT_TIMEOUT = 30.0
+
+
+class RemoteSigner(Signer):
+    """A cosmpy Signer that delegates signing to the Forge backend.
+
+    ``sign`` is used for Cosmos transaction signatures (the backend SHA-256 hashes the
+    SignDoc bytes before signing); ``sign_digest`` is used for application-level bundle
+    signatures, where the 32-byte digest is signed as-is. Both return a 64-byte
+    canonical (low-S) secp256k1 signature.
+
+    The private key never leaves Privy/the backend.
+    """
+
+    def __init__(self, backend_url: str, api_key: str, wallet_id: str, timeout: float = DEFAULT_TIMEOUT):
+        self._base = backend_url.rstrip("/")
+        self._api_key = api_key
+        self._wallet_id = wallet_id
+        self._timeout = timeout
+
+    def sign(self, message: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
+        # The backend hashes the message (SHA-256) before signing, matching cosmpy's
+        # local PrivateKey.sign semantics over the SignDoc bytes.
+        return self._remote_sign(message, prehashed=False)
+
+    def sign_digest(self, digest: bytes, deterministic: bool = False, canonicalise: bool = True) -> bytes:
+        # The digest is already hashed; the backend signs it directly.
+        return self._remote_sign(digest, prehashed=True)
+
+    def _remote_sign(self, payload: bytes, prehashed: bool) -> bytes:
+        url = f"{self._base}/api/v1/signing-wallets/{self._wallet_id}/sign"
+        body = json.dumps({"payload": payload.hex(), "prehashed": prehashed}).encode()
+        data = _post_json(url, body, self._api_key, self._timeout)
+        signature = data.get("signature")
+        if not signature:
+            raise RuntimeError("forge sign response missing 'signature'")
+        return bytes.fromhex(signature)
+
+
+class RemoteWallet(Wallet):
+    """A cosmpy Wallet backed by a Forge signing wallet (Privy server wallet).
+
+    The public key and address are fetched from the backend on construction (or supplied
+    directly) so the wallet can seal/simulate transactions before it has ever transacted
+    on-chain. ``signer()`` returns a :class:`RemoteSigner`.
+    """
+
+    def __init__(
+        self,
+        backend_url: str,
+        api_key: str,
+        wallet_id: str,
+        prefix: str = "allo",
+        timeout: float = DEFAULT_TIMEOUT,
+        public_key_hex: Optional[str] = None,
+    ):
+        self._base = backend_url.rstrip("/")
+        self._api_key = api_key
+        self._wallet_id = wallet_id
+        self._prefix = prefix
+        self._signer = RemoteSigner(backend_url, api_key, wallet_id, timeout)
+
+        reported_address: Optional[str] = None
+        if public_key_hex is None:
+            info = self._fetch_info(timeout)
+            public_key_hex = info.get("pubkey")
+            reported_address = info.get("address")
+            if not public_key_hex:
+                raise RuntimeError("forge wallet-info response missing 'pubkey'")
+
+        self._public_key = PublicKey(bytes.fromhex(public_key_hex))
+
+        # Cross-check the backend's reported address against the pubkey-derived one so a
+        # misconfigured wallet fails here rather than producing rejected transactions.
+        derived = str(Address(self._public_key, self._prefix))
+        if reported_address and reported_address != derived:
+            raise RuntimeError(
+                f"backend address {reported_address} does not match pubkey-derived address {derived}"
+            )
+
+    def _fetch_info(self, timeout: float) -> dict:
+        url = f"{self._base}/api/v1/signing-wallets/{self._wallet_id}"
+        return _get_json(url, self._api_key, timeout)
+
+    def address(self) -> Address:
+        return Address(self._public_key, self._prefix)
+
+    def public_key(self) -> PublicKey:
+        return self._public_key
+
+    def signer(self) -> Signer:
+        return self._signer
+
+
+def make_remote_wallet(
+    backend_url: str,
+    api_key: str,
+    wallet_id: str,
+    prefix: str = "allo",
+    timeout: float = DEFAULT_TIMEOUT,
+) -> RemoteWallet:
+    """Construct a backend-backed wallet for the Privy-managed signing path.
+
+    Pass the result to ``AlloraWalletConfig(wallet=...)`` (or ``AlloraWorker`` via its
+    wallet config) to sign through the Forge backend instead of a local key.
+    """
+    return RemoteWallet(backend_url, api_key, wallet_id, prefix=prefix, timeout=timeout)
+
+
+def _get_json(url: str, api_key: str, timeout: float) -> dict:
+    req = urllib.request.Request(url, method="GET")
+    req.add_header(API_KEY_HEADER, api_key)
+    return _do(req, timeout)
+
+
+def _post_json(url: str, body: bytes, api_key: str, timeout: float) -> dict:
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header(API_KEY_HEADER, api_key)
+    return _do(req, timeout)
+
+
+def _do(req: urllib.request.Request, timeout: float) -> dict:
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        raise RuntimeError(f"forge backend returned {e.code}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"failed to reach forge backend: {e.reason}") from e

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -1,4 +1,6 @@
 import asyncio
+import functools
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 import traceback
 import grpc
@@ -29,6 +31,14 @@ from allora_sdk.rpc_client.interfaces import (
 )
 
 logger = logging.getLogger("allora_sdk")
+
+# Delegated (RemoteSigner) signing makes a blocking HTTPS call to the Forge backend, so it
+# runs in a worker thread to avoid freezing the event loop. Use a dedicated pool rather than
+# asyncio's shared default ThreadPoolExecutor, so a stalled backend cannot starve unrelated
+# to_thread work — notably websocket-callback dispatch (run_in_executor(None, ...)) and faucet
+# calls. Module-level: process-lifetime; its daemon threads are reclaimed at interpreter exit.
+_signing_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="forge-signer")
+
 
 class PendingTx:
     def __init__(
@@ -454,14 +464,19 @@ class TxManager:
             fee=TxFee(amount=[ fee ], gas_limit=gas_limit, granter=granter),
         )
 
-        # Offload to a worker thread: a RemoteSigner signs via a blocking HTTPS call to
-        # the Forge backend, which would otherwise freeze the event loop. (For local
-        # wallets this is fast CPU work; running it in a thread is harmless.)
-        await asyncio.to_thread(
-            tx.sign,
-            signer=self.wallet.signer(),
-            chain_id=self.config.chain_id,
-            account_number=info.account_number,
+        # Offload to the dedicated signing pool: a RemoteSigner signs via a blocking HTTPS
+        # call to the Forge backend, which would otherwise freeze the event loop. The
+        # dedicated pool keeps a stalled backend from starving other to_thread work such as
+        # websocket-callback dispatch. (For local wallets this is fast CPU work; harmless.)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            _signing_executor,
+            functools.partial(
+                tx.sign,
+                signer=self.wallet.signer(),
+                chain_id=self.config.chain_id,
+                account_number=info.account_number,
+            ),
         )
 
         tx.complete()

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -454,7 +454,11 @@ class TxManager:
             fee=TxFee(amount=[ fee ], gas_limit=gas_limit, granter=granter),
         )
 
-        tx.sign(
+        # Offload to a worker thread: a RemoteSigner signs via a blocking HTTPS call to
+        # the Forge backend, which would otherwise freeze the event loop. (For local
+        # wallets this is fast CPU work; running it in a thread is harmless.)
+        await asyncio.to_thread(
+            tx.sign,
             signer=self.wallet.signer(),
             chain_id=self.config.chain_id,
             account_number=info.account_number,

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Optional, Union, Dict, cast
 from google.protobuf.message import Message
 
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 from cosmpy.aerial.tx import SigningCfg, Transaction, TxFee
 from cosmpy.aerial.coins import Coin
 from cosmpy.crypto.address import Address
@@ -117,7 +117,7 @@ class TxTimeoutError(Exception):
 class TxManager:
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         tx_client: CosmosTxV1Beta1ServiceLike,
         auth_client: CosmosAuthV1Beta1QueryLike,
         bank_client: CosmosBankV1Beta1QueryLike,

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -11,6 +11,7 @@ from google.protobuf.message import Message
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.aerial.tx import SigningCfg, Transaction, TxFee
 from cosmpy.aerial.coins import Coin
+from cosmpy.crypto.address import Address
 from cosmpy.aerial.client.utils import ensure_timedelta
 from cosmpy.protos.cosmos.tx.v1beta1.tx_pb2 import TxRaw as CosmpyTxRaw
 
@@ -124,6 +125,7 @@ class TxManager:
         config: AlloraNetworkConfig,
         query_interval_secs: int = 2,
         query_timeout_secs: int = 10,
+        fee_granter: Optional[str] = None,
     ):
         self.wallet = wallet
         self.tx_client = tx_client
@@ -133,6 +135,9 @@ class TxManager:
         self.config = config
         self.query_interval_secs = query_interval_secs
         self.query_timeout_secs = query_timeout_secs
+        # bech32 address of a feegrant granter (master/subsidy wallet) that pays fees on
+        # behalf of self.wallet; None means the signing wallet pays its own fees.
+        self._fee_granter = fee_granter
         self.parent_tx_id = 0
         self._parent_tx_id_lock = asyncio.Lock()
 
@@ -441,9 +446,12 @@ class TxManager:
         resolved_seq = account_seq if account_seq is not None else info.sequence
         logger.debug(f"Account info: seq={resolved_seq}, num={info.account_number}")
 
+        # When a feegrant granter is configured, set it as the fee payer so the signing
+        # wallet needs no ALLO of its own (the granter must have an on-chain allowance).
+        granter = Address(self._fee_granter) if self._fee_granter else None
         tx.seal(
             signing_cfgs=[ SigningCfg.direct(self.wallet.public_key(), sequence_num=resolved_seq) ],
-            fee=TxFee(amount=[ fee ], gas_limit=gas_limit),
+            fee=TxFee(amount=[ fee ], gas_limit=gas_limit, granter=granter),
         )
 
         tx.sign(

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.protos.emissions.v9 import (
     CanSubmitWorkerPayloadRequest,
@@ -34,7 +34,7 @@ class Forecaster:
 
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         client: AlloraRPCClient,
         topic_id: int,
         run: TForecasterRunFn,

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Union
 
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.protos.emissions.v9 import (
@@ -69,7 +69,7 @@ class Inferer:
 
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         client: AlloraRPCClient,
         topic_id: int,
         run: TInfererRunFn,

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 import logging
 import math
 from typing import List, Optional, Union, Callable, Awaitable
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.protos.emissions.v3 import Nonce, ReputerRequestNonce, ValueBundle
@@ -52,7 +52,7 @@ class Reputer:
 
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         client: AlloraRPCClient,
         topic_id: int,
         reputer_fn: ReputerFn,

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -5,7 +5,7 @@ import math
 from datetime import datetime
 from getpass import getpass
 from typing import Awaitable, Callable, ParamSpec, TypeVar, Union, cast
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import LocalWallet, Wallet
 from cosmpy.mnemonic import PrivateKey, generate_mnemonic
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
@@ -17,9 +17,13 @@ from .context import RunContext
 logger = logging.getLogger("allora_sdk")
 
 
-def init_worker_wallet(wallet: AlloraWalletConfig | None) -> LocalWallet:
+def init_worker_wallet(wallet: AlloraWalletConfig | None) -> Wallet:
     wallet_prefix = wallet.prefix if wallet else "allo"
     if wallet:
+        # A pre-built Wallet (e.g. a RemoteWallet for Privy-managed signing) takes
+        # precedence over key material.
+        if wallet.wallet:
+            return wallet.wallet
         if wallet.private_key:
             return LocalWallet(PrivateKey(bytes.fromhex(wallet.private_key)), prefix=wallet.prefix)
         if wallet.mnemonic:

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -110,7 +110,10 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         """
         wallet_initialized = init_worker_wallet(wallet)
         client = AlloraRPCClient(
-            wallet=AlloraWalletConfig(wallet=wallet_initialized),
+            wallet=AlloraWalletConfig(
+                wallet=wallet_initialized,
+                fee_granter=wallet.fee_granter if wallet else None,
+            ),
             network=network,
             debug=debug,
         )
@@ -178,7 +181,10 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         """
         wallet_initialized = init_worker_wallet(wallet)
         client = AlloraRPCClient(
-            wallet=AlloraWalletConfig(wallet=wallet_initialized),
+            wallet=AlloraWalletConfig(
+                wallet=wallet_initialized,
+                fee_granter=wallet.fee_granter if wallet else None,
+            ),
             network=network,
             debug=debug,
         )
@@ -243,7 +249,10 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         """
         wallet_initialized = init_worker_wallet(wallet)
         client = AlloraRPCClient(
-            wallet=AlloraWalletConfig(wallet=wallet_initialized),
+            wallet=AlloraWalletConfig(
+                wallet=wallet_initialized,
+                fee_granter=wallet.fee_granter if wallet else None,
+            ),
             network=network,
             debug=debug,
         )

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -16,6 +16,7 @@ from cosmpy.crypto.keypairs import PrivateKey
 
 from allora_sdk.rpc_client.remote_signer import (
     ForgeBackendError,
+    SigningWalletInfo,
     WalletConfigError,
     make_remote_wallet,
 )
@@ -246,6 +247,28 @@ def test_non_json_response_raises():
     finally:
         server.shutdown()
         thread.join(timeout=2)
+
+
+def test_signing_wallet_info_models_full_contract():
+    # forge-v2's wallet-info DTO returns evm_address / privy_wallet_id / label / created_at
+    # alongside id/address/pubkey. They are modeled as optional metadata (not silently
+    # dropped); any further unknown field is still tolerated (lenient client).
+    info = SigningWalletInfo.model_validate(
+        {
+            "id": WALLET_ID,
+            "address": "allo1xyz",
+            "pubkey": "ab" * 33,
+            "evm_address": "0xabc",
+            "privy_wallet_id": "privy-123",
+            "label": "my-wallet",
+            "created_at": "2024-01-02T03:04:05Z",
+            "some_future_field": "ignored",
+        }
+    )
+    assert info.evm_address == "0xabc"
+    assert info.privy_wallet_id == "privy-123"
+    assert info.label == "my-wallet"
+    assert info.created_at == "2024-01-02T03:04:05Z"
 
 
 def test_non_https_backend_url_rejected():

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -21,6 +21,7 @@ from allora_sdk.rpc_client.remote_signer import (
 )
 
 WALLET_ID = "11111111-1111-1111-1111-111111111111"
+API_KEY = "forge_sk_test"
 
 
 def _make_handler(priv: PrivateKey):
@@ -40,11 +41,12 @@ def _make_handler(priv: PrivateKey):
             self.wfile.write(body)
 
         def do_GET(self):
-            assert self.headers.get("X-Forge-API-Key"), "missing api key header"
+            assert self.headers.get("X-Forge-API-Key") == API_KEY, "wrong/missing api key header"
             self._send({"id": WALLET_ID, "address": address, "pubkey": pub_hex})
 
         def do_POST(self):
-            assert self.headers.get("X-Forge-API-Key"), "missing api key header"
+            assert self.headers.get("X-Forge-API-Key") == API_KEY, "wrong/missing api key header"
+            assert self.headers.get("Content-Type") == "application/json", "missing/wrong content-type"
             length = int(self.headers.get("Content-Length", "0"))
             req = json.loads(self.rfile.read(length))
             payload = bytes.fromhex(req["payload"])
@@ -69,14 +71,14 @@ def backend():
 
 def test_remote_wallet_address_and_pubkey(backend):
     priv, url = backend
-    wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    wallet = make_remote_wallet(url, API_KEY, WALLET_ID)
     assert str(wallet.address()) == str(Address(priv.public_key, "allo"))
     assert wallet.public_key().public_key_bytes == priv.public_key.public_key_bytes
 
 
 def test_remote_signer_sign_verifies(backend):
     priv, url = backend
-    wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    wallet = make_remote_wallet(url, API_KEY, WALLET_ID)
     message = b"cosmos signdoc bytes"
     sig = wallet.signer().sign(message)
     assert priv.public_key.verify(message, sig)
@@ -84,7 +86,7 @@ def test_remote_signer_sign_verifies(backend):
 
 def test_remote_signer_sign_digest_verifies(backend):
     priv, url = backend
-    wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    wallet = make_remote_wallet(url, API_KEY, WALLET_ID)
     digest = hashlib.sha256(b"worker bundle bytes").digest()
     sig = wallet.signer().sign_digest(digest)
     assert priv.public_key.verify_digest(digest, sig)
@@ -95,7 +97,7 @@ def test_from_env_builds_remote_wallet(backend, monkeypatch):
     from allora_sdk.rpc_client.remote_signer import RemoteWallet
 
     priv, url = backend
-    monkeypatch.setenv("FORGE_API_KEY", "forge_sk_test")
+    monkeypatch.setenv("FORGE_API_KEY", API_KEY)
     monkeypatch.setenv("FORGE_SIGNING_WALLET_ID", WALLET_ID)
     monkeypatch.setenv("FORGE_BACKEND_URL", url)
 
@@ -108,7 +110,7 @@ def test_from_env_reads_fee_granter(backend, monkeypatch):
     from allora_sdk.rpc_client.config import AlloraWalletConfig
 
     _priv, url = backend
-    monkeypatch.setenv("FORGE_API_KEY", "forge_sk_test")
+    monkeypatch.setenv("FORGE_API_KEY", API_KEY)
     monkeypatch.setenv("FORGE_SIGNING_WALLET_ID", WALLET_ID)
     monkeypatch.setenv("FORGE_BACKEND_URL", url)
     monkeypatch.setenv("FEE_GRANTER", "allo1granteraddrxxxxxxxxxxxxxxxxxxxxxxxxx")
@@ -181,7 +183,7 @@ def test_signature_not_matching_pubkey_rejected():
     thread.start()
     url = f"http://127.0.0.1:{server.server_address[1]}"
     try:
-        wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+        wallet = make_remote_wallet(url, API_KEY, WALLET_ID)
         with pytest.raises(ForgeBackendError, match="does not verify"):
             wallet.signer().sign(b"cosmos signdoc bytes")
     finally:
@@ -212,7 +214,7 @@ def test_address_mismatch_raises():
     url = f"http://127.0.0.1:{server.server_address[1]}"
     try:
         with pytest.raises(WalletConfigError, match="does not match"):
-            make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+            make_remote_wallet(url, API_KEY, WALLET_ID)
     finally:
         server.shutdown()
 
@@ -237,7 +239,7 @@ def test_non_json_response_raises():
     url = f"http://127.0.0.1:{server.server_address[1]}"
     try:
         with pytest.raises(ForgeBackendError, match="non-JSON"):
-            make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+            make_remote_wallet(url, API_KEY, WALLET_ID)
     finally:
         server.shutdown()
         thread.join(timeout=2)
@@ -246,7 +248,7 @@ def test_non_json_response_raises():
 def test_non_https_backend_url_rejected():
     # Plain http:// to a non-loopback host would leak the API key in cleartext.
     with pytest.raises(ValueError, match="https"):
-        make_remote_wallet("http://forge.example.com", "forge_sk_test", WALLET_ID)
+        make_remote_wallet("http://forge.example.com", API_KEY, WALLET_ID)
 
 
 def test_redirect_is_not_followed():
@@ -267,7 +269,7 @@ def test_redirect_is_not_followed():
     url = f"http://127.0.0.1:{server.server_address[1]}"
     try:
         with pytest.raises(ForgeBackendError):
-            make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+            make_remote_wallet(url, API_KEY, WALLET_ID)
     finally:
         server.shutdown()
         thread.join(timeout=2)

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -118,6 +118,12 @@ def test_address_mismatch_raises():
         server.shutdown()
 
 
+def test_non_https_backend_url_rejected():
+    # Plain http:// to a non-loopback host would leak the API key in cleartext.
+    with pytest.raises(ValueError, match="https"):
+        make_remote_wallet("http://forge.example.com", "forge_sk_test", WALLET_ID)
+
+
 def test_redirect_is_not_followed():
     # A redirecting backend must not have the X-Forge-API-Key re-sent on the next hop;
     # the client disables redirects and treats the 3xx as a backend error.

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -67,6 +67,7 @@ def backend():
         yield priv, url
     finally:
         server.shutdown()
+        thread.join(timeout=2)
 
 
 def test_remote_wallet_address_and_pubkey(backend):
@@ -210,13 +211,15 @@ def test_address_mismatch_raises():
             self.wfile.write(body)
 
     server = HTTPServer(("127.0.0.1", 0), BadHandler)
-    threading.Thread(target=server.serve_forever, daemon=True).start()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
     url = f"http://127.0.0.1:{server.server_address[1]}"
     try:
         with pytest.raises(WalletConfigError, match="does not match"):
             make_remote_wallet(url, API_KEY, WALLET_ID)
     finally:
         server.shutdown()
+        thread.join(timeout=2)
 
 
 def test_non_json_response_raises():

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -298,15 +298,36 @@ def test_non_https_backend_url_rejected():
 
 
 def test_redirect_is_not_followed():
-    # A redirecting backend must not have the X-Forge-API-Key re-sent on the next hop;
-    # the client disables redirects and treats the 3xx as a backend error.
+    # A redirecting backend must not have the X-Forge-API-Key re-sent on the next hop. Point
+    # the redirect at a second "leak" server and assert it is never contacted, so a future
+    # change that re-enables redirects (which would forward the key) fails this test — not
+    # just that the 3xx surfaces as an error.
+    leak_requests: list[str] = []
+
+    class LeakHandler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            # Record the API-key header (if any) so a leak is observable, then 200.
+            leak_requests.append(self.headers.get("X-Forge-API-Key", "<none>"))
+            self.send_response(200)
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+    leak_server = HTTPServer(("127.0.0.1", 0), LeakHandler)
+    leak_thread = threading.Thread(target=leak_server.serve_forever, daemon=True)
+    leak_thread.start()
+    leak_url = f"http://127.0.0.1:{leak_server.server_address[1]}/leak"
+
     class RedirectHandler(BaseHTTPRequestHandler):
         def log_message(self, *args):
             pass
 
         def do_GET(self):
             self.send_response(302)
-            self.send_header("Location", "http://127.0.0.1:1/leak")
+            self.send_header("Location", leak_url)
             self.end_headers()
 
     server = HTTPServer(("127.0.0.1", 0), RedirectHandler)
@@ -316,9 +337,15 @@ def test_redirect_is_not_followed():
     try:
         with pytest.raises(ForgeBackendError):
             make_remote_wallet(url, API_KEY, WALLET_ID)
+        # The redirect target must never be contacted, so the X-Forge-API-Key was not re-sent.
+        assert leak_requests == [], (
+            f"client followed the redirect and leaked headers to the target: {leak_requests}"
+        )
     finally:
         server.shutdown()
         thread.join(timeout=2)
+        leak_server.shutdown()
+        leak_thread.join(timeout=2)
 
 
 def test_sign_response_uppercase_pubkey_accepted():

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -104,6 +104,19 @@ def test_from_env_builds_remote_wallet(backend, monkeypatch):
     assert str(cfg.wallet.address()) == str(Address(priv.public_key, "allo"))
 
 
+def test_from_env_reads_fee_granter(backend, monkeypatch):
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+
+    _priv, url = backend
+    monkeypatch.setenv("FORGE_API_KEY", "forge_sk_test")
+    monkeypatch.setenv("FORGE_SIGNING_WALLET_ID", WALLET_ID)
+    monkeypatch.setenv("FORGE_BACKEND_URL", url)
+    monkeypatch.setenv("FEE_GRANTER", "allo1granteraddrxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+    cfg = AlloraWalletConfig.from_env()
+    assert cfg.fee_granter == "allo1granteraddrxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+
 def test_public_key_hex_shortcut_skips_fetch():
     # With public_key_hex (+ address) the constructor must not contact the backend,
     # so async callers can build a wallet without a blocking GET.

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -14,7 +14,7 @@ import pytest
 from cosmpy.crypto.address import Address
 from cosmpy.crypto.keypairs import PrivateKey
 
-from allora_sdk.rpc_client.remote_signer import make_remote_wallet
+from allora_sdk.rpc_client.remote_signer import WalletConfigError, make_remote_wallet
 
 WALLET_ID = "11111111-1111-1111-1111-111111111111"
 
@@ -108,7 +108,7 @@ def test_address_mismatch_raises():
     threading.Thread(target=server.serve_forever, daemon=True).start()
     url = f"http://127.0.0.1:{server.server_address[1]}"
     try:
-        with pytest.raises(RuntimeError, match="does not match"):
+        with pytest.raises(WalletConfigError, match="does not match"):
             make_remote_wallet(url, "forge_sk_test", WALLET_ID)
     finally:
         server.shutdown()

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -276,3 +276,47 @@ def test_redirect_is_not_followed():
     finally:
         server.shutdown()
         thread.join(timeout=2)
+
+
+def test_sign_response_uppercase_pubkey_accepted():
+    # bytes.hex() is lowercase, but a backend / proxy could return uppercase hex; the
+    # pubkey match must compare decoded bytes, not case-sensitive strings, so a valid
+    # signature is not falsely rejected (parity with allora-sdk-go / allora-sdk-ts).
+    priv = PrivateKey()
+    pub_hex = priv.public_key.public_key_bytes.hex()
+    address = str(Address(priv.public_key, "allo"))
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def _send(self, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            self._send({"id": WALLET_ID, "address": address, "pubkey": pub_hex})
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            req = json.loads(self.rfile.read(length))
+            payload = bytes.fromhex(req["payload"])
+            sig = priv.sign_digest(payload) if req["prehashed"] else priv.sign(payload)
+            # Return the pubkey in UPPERCASE hex to exercise the case-insensitive compare.
+            self._send({"signature": sig.hex(), "pubkey": pub_hex.upper()})
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        wallet = make_remote_wallet(url, API_KEY, WALLET_ID)
+        message = b"cosmos signdoc bytes"
+        sig = wallet.signer().sign(message)
+        assert priv.public_key.verify(message, sig)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -121,6 +121,19 @@ def test_from_env_reads_fee_granter(backend, monkeypatch):
     assert cfg.fee_granter == "allo1granteraddrxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 
+def test_from_env_conflicting_credentials_rejected(monkeypatch):
+    # Forge env vars set alongside a stale local key (a common mid-migration state) must
+    # fail loudly, not silently sign through Forge — mirrors __post_init__'s single-source
+    # guard. The check fires before any backend contact.
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+
+    monkeypatch.setenv("FORGE_API_KEY", API_KEY)
+    monkeypatch.setenv("FORGE_SIGNING_WALLET_ID", WALLET_ID)
+    monkeypatch.setenv("PRIVATE_KEY", "deadbeef")
+    with pytest.raises(ValueError, match="exactly one signing source"):
+        AlloraWalletConfig.from_env()
+
+
 def test_public_key_hex_shortcut_skips_fetch():
     # With public_key_hex (+ address) the constructor must not contact the backend,
     # so async callers can build a wallet without a blocking GET.

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -90,6 +90,48 @@ def test_remote_signer_sign_digest_verifies(backend):
     assert priv.public_key.verify_digest(digest, sig)
 
 
+def test_signature_not_matching_pubkey_rejected():
+    # The wallet pins the pubkey from wallet-info; a signature that does not verify
+    # against it (backend bug / MITM) must be rejected locally, not broadcast.
+    good = PrivateKey()
+    bad = PrivateKey()
+    good_pub = good.public_key.public_key_bytes.hex()
+    address = str(Address(good.public_key, "allo"))
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def _send(self, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            self._send({"id": WALLET_ID, "address": address, "pubkey": good_pub})
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            req = json.loads(self.rfile.read(length))
+            payload = bytes.fromhex(req["payload"])
+            sig = bad.sign_digest(payload) if req["prehashed"] else bad.sign(payload)
+            self._send({"signature": sig.hex(), "pubkey": good_pub})
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+        with pytest.raises(ForgeBackendError, match="does not verify"):
+            wallet.signer().sign(b"cosmos signdoc bytes")
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
 def test_address_mismatch_raises():
     # A backend that reports an address inconsistent with the pubkey must be rejected.
     priv = PrivateKey()

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -90,6 +90,36 @@ def test_remote_signer_sign_digest_verifies(backend):
     assert priv.public_key.verify_digest(digest, sig)
 
 
+def test_public_key_hex_shortcut_skips_fetch():
+    # With public_key_hex (+ address) the constructor must not contact the backend,
+    # so async callers can build a wallet without a blocking GET.
+    priv = PrivateKey()
+    pub_hex = priv.public_key.public_key_bytes.hex()
+    address = str(Address(priv.public_key, "allo"))
+    wallet = make_remote_wallet(
+        "https://forge.invalid",
+        "forge_sk_test",
+        WALLET_ID,
+        public_key_hex=pub_hex,
+        address=address,
+    )
+    assert str(wallet.address()) == address
+    assert wallet.public_key().public_key_bytes == priv.public_key.public_key_bytes
+
+
+def test_public_key_hex_shortcut_address_mismatch_raises():
+    priv = PrivateKey()
+    pub_hex = priv.public_key.public_key_bytes.hex()
+    with pytest.raises(WalletConfigError, match="does not match"):
+        make_remote_wallet(
+            "https://forge.invalid",
+            "forge_sk_test",
+            WALLET_ID,
+            public_key_hex=pub_hex,
+            address="allo1wrongaddressxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        )
+
+
 def test_signature_not_matching_pubkey_rejected():
     # The wallet pins the pubkey from wallet-info; a signature that does not verify
     # against it (backend bug / MITM) must be rejected locally, not broadcast.

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -151,6 +151,13 @@ def test_public_key_hex_shortcut_address_mismatch_raises():
         )
 
 
+def test_non_uuid_wallet_id_rejected():
+    # forge-v2 keys signing wallets by Privy UUID; a non-UUID wallet_id is a config typo and
+    # must fail locally (parity with allora-sdk-go's uuid.Parse guard) without a network call.
+    with pytest.raises(WalletConfigError, match="UUID"):
+        make_remote_wallet("https://forge.invalid", API_KEY, "not-a-uuid")
+
+
 def test_signature_not_matching_pubkey_rejected():
     # The wallet pins the pubkey from wallet-info; a signature that does not verify
     # against it (backend bug / MITM) must be rejected locally, not broadcast.

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -118,6 +118,32 @@ def test_address_mismatch_raises():
         server.shutdown()
 
 
+def test_non_json_response_raises():
+    # A 200 with a non-JSON body (e.g. a gateway HTML page) must surface as a clear
+    # ForgeBackendError, not a bare JSONDecodeError.
+    class HtmlHandler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            body = b"<html>gateway error</html>"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("127.0.0.1", 0), HtmlHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with pytest.raises(ForgeBackendError, match="non-JSON"):
+            make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
 def test_non_https_backend_url_rejected():
     # Plain http:// to a non-loopback host would leak the API key in cleartext.
     with pytest.raises(ValueError, match="https"):

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -90,6 +90,20 @@ def test_remote_signer_sign_digest_verifies(backend):
     assert priv.public_key.verify_digest(digest, sig)
 
 
+def test_from_env_builds_remote_wallet(backend, monkeypatch):
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+    from allora_sdk.rpc_client.remote_signer import RemoteWallet
+
+    priv, url = backend
+    monkeypatch.setenv("FORGE_API_KEY", "forge_sk_test")
+    monkeypatch.setenv("FORGE_SIGNING_WALLET_ID", WALLET_ID)
+    monkeypatch.setenv("FORGE_BACKEND_URL", url)
+
+    cfg = AlloraWalletConfig.from_env()
+    assert isinstance(cfg.wallet, RemoteWallet)
+    assert str(cfg.wallet.address()) == str(Address(priv.public_key, "allo"))
+
+
 def test_public_key_hex_shortcut_skips_fetch():
     # With public_key_hex (+ address) the constructor must not contact the backend,
     # so async callers can build a wallet without a blocking GET.

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -1,0 +1,114 @@
+"""Tests for the Privy-managed (delegated) remote signer.
+
+A local HTTP server stands in for the Forge backend and signs with a real cosmpy
+private key, so the test exercises the full request/response path and proves the
+signatures the RemoteSigner returns verify against the wallet's public key.
+"""
+
+import hashlib
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from cosmpy.crypto.address import Address
+from cosmpy.crypto.keypairs import PrivateKey
+
+from allora_sdk.rpc_client.remote_signer import make_remote_wallet
+
+WALLET_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _make_handler(priv: PrivateKey):
+    pub_hex = priv.public_key.public_key_bytes.hex()
+    address = str(Address(priv.public_key, "allo"))
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # silence test server logging
+            pass
+
+        def _send(self, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            assert self.headers.get("X-Forge-API-Key"), "missing api key header"
+            self._send({"id": WALLET_ID, "address": address, "pubkey": pub_hex})
+
+        def do_POST(self):
+            assert self.headers.get("X-Forge-API-Key"), "missing api key header"
+            length = int(self.headers.get("Content-Length", "0"))
+            req = json.loads(self.rfile.read(length))
+            payload = bytes.fromhex(req["payload"])
+            sig = priv.sign_digest(payload) if req["prehashed"] else priv.sign(payload)
+            self._send({"signature": sig.hex(), "pubkey": pub_hex})
+
+    return Handler
+
+
+@pytest.fixture
+def backend():
+    priv = PrivateKey()
+    server = HTTPServer(("127.0.0.1", 0), _make_handler(priv))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield priv, url
+    finally:
+        server.shutdown()
+
+
+def test_remote_wallet_address_and_pubkey(backend):
+    priv, url = backend
+    wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    assert str(wallet.address()) == str(Address(priv.public_key, "allo"))
+    assert wallet.public_key().public_key_bytes == priv.public_key.public_key_bytes
+
+
+def test_remote_signer_sign_verifies(backend):
+    priv, url = backend
+    wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    message = b"cosmos signdoc bytes"
+    sig = wallet.signer().sign(message)
+    assert priv.public_key.verify(message, sig)
+
+
+def test_remote_signer_sign_digest_verifies(backend):
+    priv, url = backend
+    wallet = make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    digest = hashlib.sha256(b"worker bundle bytes").digest()
+    sig = wallet.signer().sign_digest(digest)
+    assert priv.public_key.verify_digest(digest, sig)
+
+
+def test_address_mismatch_raises():
+    # A backend that reports an address inconsistent with the pubkey must be rejected.
+    priv = PrivateKey()
+    pub_hex = priv.public_key.public_key_bytes.hex()
+
+    class BadHandler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            body = json.dumps(
+                {"id": WALLET_ID, "address": "allo1wrongaddressxxxxxxxxxxxxxxxxxxxxxxxxxx", "pubkey": pub_hex}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("127.0.0.1", 0), BadHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with pytest.raises(RuntimeError, match="does not match"):
+            make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    finally:
+        server.shutdown()

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -14,7 +14,11 @@ import pytest
 from cosmpy.crypto.address import Address
 from cosmpy.crypto.keypairs import PrivateKey
 
-from allora_sdk.rpc_client.remote_signer import WalletConfigError, make_remote_wallet
+from allora_sdk.rpc_client.remote_signer import (
+    ForgeBackendError,
+    WalletConfigError,
+    make_remote_wallet,
+)
 
 WALLET_ID = "11111111-1111-1111-1111-111111111111"
 
@@ -112,3 +116,27 @@ def test_address_mismatch_raises():
             make_remote_wallet(url, "forge_sk_test", WALLET_ID)
     finally:
         server.shutdown()
+
+
+def test_redirect_is_not_followed():
+    # A redirecting backend must not have the X-Forge-API-Key re-sent on the next hop;
+    # the client disables redirects and treats the 3xx as a backend error.
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            self.send_response(302)
+            self.send_header("Location", "http://127.0.0.1:1/leak")
+            self.end_headers()
+
+    server = HTTPServer(("127.0.0.1", 0), RedirectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with pytest.raises(ForgeBackendError):
+            make_remote_wallet(url, "forge_sk_test", WALLET_ID)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)

--- a/tests/test_tx_manager_simulation.py
+++ b/tests/test_tx_manager_simulation.py
@@ -9,7 +9,7 @@ from allora_sdk.rpc_client.config import AlloraNetworkConfig
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError, TxManager
 
 
-def _make_manager() -> TxManager:
+def _make_manager(fee_granter: str | None = None) -> TxManager:
     wallet = Mock()
     wallet.address.return_value = "allo1sender"
     wallet.public_key.return_value = Mock()
@@ -27,7 +27,13 @@ def _make_manager() -> TxManager:
         bank_client=bank_client,
         feemarket_client=feemarket_client,
         config=config,
+        fee_granter=fee_granter,
     )
+
+
+def test_fee_granter_is_stored() -> None:
+    assert _make_manager()._fee_granter is None
+    assert _make_manager(fee_granter="allo1granter")._fee_granter == "allo1granter"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Add an opt-in signing path where a worker holds no private key and signing is delegated to the Forge backend (Privy server wallet).

- `RemoteSigner` (cosmpy `Signer`): `sign()` for tx SignDocs (backend SHA-256 hashes), `sign_digest()` for worker/reputer bundle signatures (signed as-is).
- `RemoteWallet` (cosmpy `Wallet`): fetches the pubkey/address from the backend and cross-checks the address; `signer()` returns the `RemoteSigner`.
- `make_remote_wallet()` factory; pass via `AlloraWalletConfig(wallet=...)`.
- Widen `AlloraWalletConfig.wallet` to cosmpy `Wallet` and accept a pre-built wallet in `init_worker_wallet`.

Linear: [ENGN-8615](https://linear.app/alloralabs/issue/ENGN-8615)

## Test plan
- [x] Signatures verified against the wallet pubkey via a local test backend (both `sign` and `sign_digest`)
- [ ] `pytest tests` in CI (requires `make codegen` / protoc)
- [ ] End-to-end against a live Forge backend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Privy‑delegated signing so workers sign txs and bundles via the Forge backend (Privy server wallet) with no local key, plus feegrant support and a dedicated signing thread pool. Implements ENGN-8615.

- **New Features**
  - `RemoteSigner`/`RemoteWallet` for delegated signing; `sign` hashes SignDoc, `sign_digest` signs a 32‑byte digest; `make_remote_wallet(...)` factory.
  - `AlloraWalletConfig.wallet` and all sinks now accept any cosmpy `Wallet` (not just `LocalWallet`); worker constructors and `TxManager` updated.
  - Env setup: `AlloraWalletConfig.from_env()` builds a remote wallet when `FORGE_API_KEY`/`FORGE_SIGNING_WALLET_ID` are set (`FORGE_BACKEND_URL` defaults to prod); `FEE_GRANTER` enables gas subsidy via feegrant.
  - Fee subsidy: new `fee_granter` option flows into `TxManager` and seals fees with a granter.
  - Non‑blocking: tx and bundle signing run on a dedicated `_signing_executor` so backend HTTPS calls never starve the asyncio loop.
  - Exposed types: `ForgeBackendClient` (injectable transport) and error classes (`RemoteSignerError`, `ForgeBackendError`, `WalletConfigError`) are exported; README documents usage.

- **Bug Fixes**
  - Security/transport: require https backend URLs (loopback http allowed), never follow redirects with the API key, URL‑encode `wallet_id`, validate `wallet_id` is a UUID, cap response size, and reject non‑JSON or non‑object responses.
  - Correctness: require and pin the wallet pubkey in `RemoteSigner`; verify every backend signature locally; compare response pubkeys by bytes (case‑insensitive); validate 64‑byte sigs and 33‑byte pubkeys; reject empty payloads and `canonicalise=False`; cross‑check backend address with the pubkey and wallet‑info `id` with the requested id.
  - Config/UX: enforce exactly one wallet credential source (including in `from_env`), align `prefix` to a supplied wallet, use the wallet’s prefix when building local keys, and log the concrete wallet type at init.
  - Robustness: typed Pydantic response models (`SigningWalletInfo` now reflects the full backend contract, including `evm_address`, `privy_wallet_id`, `label`, `created_at`); shared `requests.Session` in `ForgeBackendClient`; backend error bodies are truncated in exceptions.

<sup>Written for commit 43220d6225e8ea31a0119785ccdca7492ba2e5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

