### PR TITLE
feat: auto-provision managed wallet bound to the worker's topic (ENGN-8646)

### DIFF
--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -31,6 +31,11 @@ class AlloraWalletConfig:
     wallet: Optional[Wallet] = None
     prefix: str = "allo"
     fee_granter: Optional[str] = None
+    # Managed (Privy) custody without an explicit wallet: when forge_api_key is set and no
+    # wallet/key is provided, the worker provisions a backend-signed wallet bound to its topic
+    # (get-or-create) at startup. forge_backend_url defaults to the public Forge backend.
+    forge_api_key: Optional[str] = None
+    forge_backend_url: Optional[str] = None
 
     @classmethod
     def from_env(cls, env_prefix: str | None = None) -> 'AlloraWalletConfig':
@@ -44,12 +49,21 @@ class AlloraWalletConfig:
         # it can build the wallet via make_remote_wallet(..., public_key_hex=...) directly.
         api_key = os.getenv(p + "FORGE_API_KEY")
         wallet_id = os.getenv(p + "FORGE_SIGNING_WALLET_ID")
+        backend_url = os.getenv(p + "FORGE_BACKEND_URL", "https://forge.allora.network")
         if api_key and wallet_id:
             from .remote_signer import make_remote_wallet
 
-            backend_url = os.getenv(p + "FORGE_BACKEND_URL", "https://forge.allora.network")
             wallet = make_remote_wallet(backend_url, api_key, wallet_id, prefix=prefix)
             return cls(wallet=wallet, prefix=prefix, fee_granter=fee_granter)
+        if api_key:
+            # Managed custody, no explicit wallet id: defer to the worker, which provisions a
+            # wallet bound to its topic (one worker = one topic) at startup.
+            return cls(
+                forge_api_key=api_key,
+                forge_backend_url=backend_url,
+                prefix=prefix,
+                fee_granter=fee_granter,
+            )
 
         return cls(
             private_key=os.getenv(p + "PRIVATE_KEY"),
@@ -64,6 +78,10 @@ class AlloraWalletConfig:
             x is not None
             for x in (self.private_key, self.mnemonic, self.mnemonic_file, self.wallet)
         )
+        # Managed (Privy) custody is a valid "deferred" source: the wallet is provisioned later
+        # from forge_api_key + the worker's topic, so no local credential is present here.
+        if sources == 0 and self.forge_api_key:
+            return
         if sources == 0:
             raise ValueError("No wallet credentials provided")
         if sources > 1:

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -147,6 +147,16 @@ class ForgeBackendClient:
         raw = self._request("POST", "/api/v1/signing-wallets", json.dumps(body))
         return _validate(SigningWalletInfo, raw, "provision-wallet")
 
+    def clear_association(self, wallet_id: str) -> None:
+        """Release a managed wallet's topic binding (Forge-side bookkeeping only; does NOT
+        unregister the worker on-chain). Mirrors POST
+        /api/v1/signing-wallets/{id}/clear-association. Raises :class:`ForgeBackendError` on a
+        non-2xx response (e.g. 404 for an unknown / foreign / already-cleared wallet), so the
+        caller decides whether an unbind failure is fatal or best-effort.
+        """
+        wid = urllib.parse.quote(wallet_id, safe="")
+        self._request("POST", f"/api/v1/signing-wallets/{wid}/clear-association")
+
     def _request(self, method: str, path: str, body: Optional[str] = None) -> dict[str, Any]:
         headers = {API_KEY_HEADER: self._api_key}
         if body is not None:

--- a/src/allora_sdk/rpc_client/remote_signer.py
+++ b/src/allora_sdk/rpc_client/remote_signer.py
@@ -135,6 +135,18 @@ class ForgeBackendClient:
         raw = self._request("POST", f"/api/v1/signing-wallets/{wid}/sign", body)
         return _validate(SignResult, raw, "sign")
 
+    def provision_wallet(self, topic_id: int, label: Optional[str] = None) -> SigningWalletInfo:
+        """Idempotently get-or-create the user's signing wallet bound to ``topic_id`` and return
+        its non-secret info (id, address, pubkey). Rides on POST /api/v1/signing-wallets with a
+        ``topic_id`` body (a static /provision sub-route collides with /:id in the backend router).
+        Safe to call on every worker start: the backend enforces one wallet per (user, topic).
+        """
+        body: dict[str, Any] = {"topic_id": topic_id}
+        if label:
+            body["label"] = label
+        raw = self._request("POST", "/api/v1/signing-wallets", json.dumps(body))
+        return _validate(SigningWalletInfo, raw, "provision-wallet")
+
     def _request(self, method: str, path: str, body: Optional[str] = None) -> dict[str, Any]:
         headers = {API_KEY_HEADER: self._api_key}
         if body is not None:
@@ -384,4 +396,33 @@ def make_remote_wallet(
         public_key_hex=public_key_hex,
         address=address,
         client=client,
+    )
+
+
+def provision_remote_wallet(
+    backend_url: str,
+    api_key: str,
+    topic_id: int,
+    label: Optional[str] = None,
+    prefix: str = "allo",
+    timeout: float = DEFAULT_TIMEOUT,
+    client: Optional[ForgeBackendClient] = None,
+) -> RemoteWallet:
+    """Idempotently get-or-create the user's managed wallet bound to ``topic_id`` (one worker =
+    one topic) and return a :class:`RemoteWallet` for it. Safe to call on every worker start.
+
+    The provisioned wallet's pubkey/address are returned by the provision call, so the resulting
+    RemoteWallet is built without a second (blocking) wallet-info fetch.
+    """
+    c = client if client is not None else ForgeBackendClient(backend_url, api_key, timeout)
+    info = c.provision_wallet(topic_id, label)
+    return RemoteWallet(
+        backend_url,
+        api_key,
+        info.id,
+        prefix=prefix,
+        timeout=timeout,
+        public_key_hex=info.pubkey,
+        address=info.address,
+        client=c,
     )

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -17,13 +17,26 @@ from .context import RunContext
 logger = logging.getLogger("allora_sdk")
 
 
-def init_worker_wallet(wallet: AlloraWalletConfig | None) -> Wallet:
+def init_worker_wallet(wallet: AlloraWalletConfig | None, topic_id: int | None = None) -> Wallet:
     wallet_prefix = wallet.prefix if wallet else "allo"
     if wallet:
         # A pre-built Wallet (e.g. a RemoteWallet for Privy-managed signing) takes
         # precedence over key material.
         if wallet.wallet:
             return wallet.wallet
+        # Managed (Privy) custody with no explicit wallet: provision a backend-signed wallet
+        # bound to this worker's topic (get-or-create; one worker = one topic).
+        if wallet.forge_api_key:
+            if topic_id is None:
+                raise ValueError("managed-wallet provisioning requires a topic_id")
+            from allora_sdk.rpc_client.remote_signer import provision_remote_wallet
+
+            return provision_remote_wallet(
+                backend_url=wallet.forge_backend_url or "https://forge.allora.network",
+                api_key=wallet.forge_api_key,
+                topic_id=topic_id,
+                prefix=wallet.prefix,
+            )
         if wallet.private_key:
             return LocalWallet(PrivateKey(bytes.fromhex(wallet.private_key)), prefix=wallet.prefix)
         if wallet.mnemonic:

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -108,7 +108,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         Returns:
             An instance of AlloraWorker configured as an inferer
         """
-        wallet_initialized = init_worker_wallet(wallet)
+        wallet_initialized = init_worker_wallet(wallet, topic_id)
         client = AlloraRPCClient(
             wallet=AlloraWalletConfig(
                 wallet=wallet_initialized,
@@ -179,7 +179,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             UnsupportedLossMethodError: If loss_fn is None and the topic's loss_method
                                         is not supported by the SDK's default implementations.
         """
-        wallet_initialized = init_worker_wallet(wallet)
+        wallet_initialized = init_worker_wallet(wallet, topic_id)
         client = AlloraRPCClient(
             wallet=AlloraWalletConfig(
                 wallet=wallet_initialized,
@@ -247,7 +247,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         Returns:
             An instance of AlloraWorker configured as a forecaster
         """
-        wallet_initialized = init_worker_wallet(wallet)
+        wallet_initialized = init_worker_wallet(wallet, topic_id)
         client = AlloraRPCClient(
             wallet=AlloraWalletConfig(
                 wallet=wallet_initialized,

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -46,6 +46,10 @@ def _make_handler(priv: PrivateKey):
 
         def do_POST(self):
             assert self.headers.get("X-Forge-API-Key") == API_KEY, "wrong/missing api key header"
+            if self.path.endswith("/clear-association"):
+                # Clear-association carries no request body (and thus no Content-Type).
+                self._send({"message": "association cleared"})
+                return
             assert self.headers.get("Content-Type") == "application/json", "missing/wrong content-type"
             length = int(self.headers.get("Content-Length", "0"))
             req = json.loads(self.rfile.read(length))
@@ -122,6 +126,15 @@ def test_from_env_reads_fee_granter(backend, monkeypatch):
 
     cfg = AlloraWalletConfig.from_env()
     assert cfg.fee_granter == "allo1granteraddrxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+
+def test_clear_association(backend):
+    from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
+
+    _priv, url = backend
+    client = ForgeBackendClient(url, API_KEY)
+    # A 2xx response returns without raising (the topic binding was released).
+    client.clear_association(WALLET_ID)
 
 
 def test_provision_remote_wallet(backend):

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -49,6 +49,10 @@ def _make_handler(priv: PrivateKey):
             assert self.headers.get("Content-Type") == "application/json", "missing/wrong content-type"
             length = int(self.headers.get("Content-Length", "0"))
             req = json.loads(self.rfile.read(length))
+            if not self.path.endswith("/sign"):
+                # Provision (POST /api/v1/signing-wallets with topic_id): get-or-create wallet.
+                self._send({"id": WALLET_ID, "address": address, "pubkey": pub_hex, "topic_id": req.get("topic_id")})
+                return
             payload = bytes.fromhex(req["payload"])
             sig = priv.sign_digest(payload) if req["prehashed"] else priv.sign(payload)
             self._send({"signature": sig.hex(), "pubkey": pub_hex})
@@ -118,6 +122,49 @@ def test_from_env_reads_fee_granter(backend, monkeypatch):
 
     cfg = AlloraWalletConfig.from_env()
     assert cfg.fee_granter == "allo1granteraddrxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+
+def test_provision_remote_wallet(backend):
+    from allora_sdk.rpc_client.remote_signer import provision_remote_wallet
+
+    priv, url = backend
+    wallet = provision_remote_wallet(url, API_KEY, topic_id=42)
+    assert str(wallet.address()) == str(Address(priv.public_key, "allo"))
+    # The provisioned wallet signs through the same backend.
+    sig = wallet.signer().sign(b"signdoc bytes")
+    assert priv.public_key.verify(b"signdoc bytes", sig)
+
+
+def test_from_env_defers_managed_provision(monkeypatch):
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+
+    # API key but no wallet id: from_env defers provisioning (no wallet built, no network call).
+    monkeypatch.setenv("FORGE_API_KEY", API_KEY)
+    monkeypatch.delenv("FORGE_SIGNING_WALLET_ID", raising=False)
+    monkeypatch.setenv("FORGE_BACKEND_URL", "https://forge.invalid")
+
+    cfg = AlloraWalletConfig.from_env()
+    assert cfg.wallet is None
+    assert cfg.forge_api_key == API_KEY
+
+
+def test_init_worker_wallet_provisions_for_topic(backend):
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+    from allora_sdk.worker.utils import init_worker_wallet
+
+    priv, url = backend
+    cfg = AlloraWalletConfig(forge_api_key=API_KEY, forge_backend_url=url)
+    wallet = init_worker_wallet(cfg, topic_id=7)
+    assert str(wallet.address()) == str(Address(priv.public_key, "allo"))
+
+
+def test_init_worker_wallet_managed_requires_topic():
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+    from allora_sdk.worker.utils import init_worker_wallet
+
+    cfg = AlloraWalletConfig(forge_api_key=API_KEY, forge_backend_url="https://forge.invalid")
+    with pytest.raises(ValueError, match="topic_id"):
+        init_worker_wallet(cfg, topic_id=None)
 
 
 def test_public_key_hex_shortcut_skips_fetch():


### PR DESCRIPTION
## Summary

When a worker prefers managed (Privy) custody but no `FORGE_SIGNING_WALLET_ID` is set, provision a backend-signed wallet bound to the worker's topic at startup (idempotent get-or-create; one worker = one topic), instead of falling back to a local key.

Linear: [ENGN-8646](https://linear.app/alloralabs/issue/ENGN-8646/auto-provision-managed-privy-wallets-bound-to-a-topic-before-worker). Pairs with forge-v2 PR (the `POST /signing-wallets {topic_id}` get-or-create endpoint).

- `ForgeBackendClient.provision_wallet(topic_id, label)` → `POST /api/v1/signing-wallets` with a `topic_id` body; `provision_remote_wallet()` builds a `RemoteWallet` from the returned id/pubkey/address (no extra wallet-info fetch).
- `AlloraWalletConfig` gains `forge_api_key`/`forge_backend_url`; `from_env()` defers provisioning (no wallet built, no network call) when an API key is set without a wallet id.
- `init_worker_wallet(config, topic_id)` provisions for the topic; the inferer/forecaster/reputer constructors pass their `topic_id`.
- Explicit `private_key` / `mnemonic` / `FORGE_SIGNING_WALLET_ID` paths are unchanged.

## Test plan
- [x] `py_compile` clean on changed modules
- [x] Tests added (`test_provision_remote_wallet`, `test_from_env_defers_managed_provision`, `test_init_worker_wallet_provisions_for_topic`, `test_init_worker_wallet_managed_requires_topic`) against the local fake-backend harness
- [ ] Run full suite in CI (a fresh worktree lacks the generated `protos`/`rest`/`interfaces` packages, so the suite can't be collected locally without the codegen step)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-provisions a managed (Privy) signing wallet bound to the worker’s topic at startup when `FORGE_API_KEY` is set and no `FORGE_SIGNING_WALLET_ID` is provided. Implements ENGN-8646 to enforce one worker = one topic and adds an API to clear a wallet–topic binding.

- **New Features**
  - Added `ForgeBackendClient.provision_wallet(topic_id, label)` → `POST /api/v1/signing-wallets` (idempotent get-or-create) and `provision_remote_wallet(...)` to build a `RemoteWallet` from the response.
  - Added `ForgeBackendClient.clear_association(wallet_id)` → `POST /api/v1/signing-wallets/:id/clear-association` to release a wallet’s topic binding (Forge-side only).
  - Extended `AlloraWalletConfig` with `forge_api_key`/`forge_backend_url`; `from_env()` defers provisioning when only an API key is set and `__post_init__` allows deferred managed custody.
  - Updated `init_worker_wallet(config, topic_id)` to provision for the topic; inferer/forecaster/reputer now pass `topic_id`.
  - Kept `private_key`, `mnemonic`, and `FORGE_SIGNING_WALLET_ID` paths unchanged.

<sup>Written for commit 0c20c8fa762cb4c420b1bf768356e854a8b0bcb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

