### PR TITLE
feat(wallet): accept an injected cosmpy Wallet (custodial/remote signer seam)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,14 +82,12 @@ include = [
     "src/allora_sdk/**/*"
 ]
 artifacts = [
-    "src/allora_sdk/protos/**/*",
-    "src/allora_sdk/rest/**/*",
+    "src/allora_sdk/rpc_client/**/*",
 ]
 
 [tool.hatch.build.targets.sdist]
 artifacts = [
-    "src/allora_sdk/protos/**/*",
-    "src/allora_sdk/rest/**/*",
+    "src/allora_sdk/rpc_client/**/*",
 ]
 exclude = [
     "/.github",

--- a/src/allora_sdk/rpc_client/client.py
+++ b/src/allora_sdk/rpc_client/client.py
@@ -18,7 +18,7 @@ from grpclib.client import Channel
 from grpclib.protocol import H2Protocol
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.urls import Protocol, parse_url
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import LocalWallet, Wallet
 from cosmpy.crypto.keypairs import PrivateKey
 
 import allora_sdk.rpc_client.protos.cosmos.base.tendermint.v1beta1 as tendermint_v1beta1
@@ -96,7 +96,7 @@ class AlloraRPCClient:
     including queries, transactions, and event subscriptions.
     """
 
-    wallet: Optional[LocalWallet] = None
+    wallet: Optional[Wallet] = None
     tx_manager: Optional[TxManager] = None
 
     def __init__(
@@ -187,9 +187,9 @@ class AlloraRPCClient:
             return
 
         try:
-            if wallet.wallet:
+            if wallet.wallet is not None:
                 self.wallet = wallet.wallet
-                logger.debug("Wallet initialized from LocalWallet")
+                logger.debug("Wallet initialized from injected Wallet instance (%s)", type(self.wallet).__name__)
             elif wallet.private_key:
                 pk = PrivateKey(bytes.fromhex(wallet.private_key))
                 self.wallet = LocalWallet(pk, prefix="allo")

--- a/src/allora_sdk/rpc_client/config.py
+++ b/src/allora_sdk/rpc_client/config.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 from cosmpy.aerial.config import NetworkConfig
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 
 
 @dataclass
@@ -14,14 +14,19 @@ class AlloraWalletConfig:
     - private_key: Hex-encoded private key string.
     - mnemonic: Mnemonic phrase string.
     - mnemonic_file: Path to a file containing the mnemonic phrase.
-    - wallet: An existing LocalWallet instance.
+    - wallet: An existing wallet instance. This is the abstract cosmpy ``Wallet``
+      (not only ``LocalWallet``), so a custodial/remote-signing implementation
+      (e.g. a Privy-backed wallet that never materializes the private key) can be
+      injected here. When set, it takes precedence and ``private_key`` /
+      ``mnemonic`` / ``mnemonic_file`` are IGNORED (there is no fallback chain —
+      the injected wallet is used as-is).
 
     The address prefix can also be specified (default is "allo").
     """
     private_key: Optional[str] = None
     mnemonic: Optional[str] = None
     mnemonic_file: Optional[str] = None
-    wallet: Optional[LocalWallet] = None
+    wallet: Optional[Wallet] = None
     prefix: str = "allo"
 
     @classmethod

--- a/src/allora_sdk/rpc_client/tx_manager.py
+++ b/src/allora_sdk/rpc_client/tx_manager.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Optional, Union, Dict, cast
 from google.protobuf.message import Message
 
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 from cosmpy.aerial.tx import SigningCfg, Transaction, TxFee
 from cosmpy.aerial.coins import Coin
 from cosmpy.aerial.client.utils import ensure_timedelta
@@ -116,7 +116,9 @@ class TxTimeoutError(Exception):
 class TxManager:
     def __init__(
         self,
-        wallet: LocalWallet,
+        # Abstract cosmpy Wallet, not only LocalWallet, so a custodial/remote
+        # signer (e.g. a Privy-backed wallet) can be injected and used here.
+        wallet: Wallet,
         tx_client: CosmosTxV1Beta1ServiceLike,
         auth_client: CosmosAuthV1Beta1QueryLike,
         bank_client: CosmosBankV1Beta1QueryLike,

--- a/src/allora_sdk/worker/forecaster.py
+++ b/src/allora_sdk/worker/forecaster.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.protos.emissions.v10 import (
     CanSubmitWorkerPayloadRequest,
@@ -35,7 +35,7 @@ class Forecaster:
 
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         client: AlloraRPCClient,
         topic_id: int,
         run: TForecasterRunFn,

--- a/src/allora_sdk/worker/inferer.py
+++ b/src/allora_sdk/worker/inferer.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Union
 
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.protos.emissions.v10 import (
@@ -72,7 +72,7 @@ class Inferer:
 
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         client: AlloraRPCClient,
         topic_id: int,
         run: TInfererRunFn,

--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 import logging
 import math
 from typing import List, Optional, Union, Callable, Awaitable
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import Wallet
 
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.protos.emissions.v3 import Nonce, ReputerRequestNonce
@@ -56,7 +56,7 @@ class Reputer:
 
     def __init__(
         self,
-        wallet: LocalWallet,
+        wallet: Wallet,
         client: AlloraRPCClient,
         topic_id: int,
         reputer_fn: ReputerFn,

--- a/src/allora_sdk/worker/utils.py
+++ b/src/allora_sdk/worker/utils.py
@@ -5,7 +5,7 @@ import math
 from datetime import datetime
 from getpass import getpass
 from typing import Awaitable, Callable, ParamSpec, TypeVar, Union, cast
-from cosmpy.aerial.wallet import LocalWallet
+from cosmpy.aerial.wallet import LocalWallet, Wallet
 from cosmpy.mnemonic import PrivateKey, generate_mnemonic
 from allora_sdk.rpc_client.client import AlloraRPCClient
 from allora_sdk.rpc_client.config import AlloraWalletConfig
@@ -16,9 +16,13 @@ from .context import RunContext
 logger = logging.getLogger("allora_sdk")
 
 
-def init_worker_wallet(wallet: AlloraWalletConfig | None) -> LocalWallet:
+def init_worker_wallet(wallet: AlloraWalletConfig | None) -> Wallet:
     wallet_prefix = wallet.prefix if wallet else "allo"
     if wallet:
+        # An injected wallet takes precedence: it lets a custodial/remote signer
+        # (e.g. Privy) be supplied without ever materializing a private key here.
+        if wallet.wallet is not None:
+            return wallet.wallet
         if wallet.private_key:
             return LocalWallet(PrivateKey(bytes.fromhex(wallet.private_key)), prefix=wallet.prefix)
         if wallet.mnemonic:

--- a/tests/test_tx_manager_simulation.py
+++ b/tests/test_tx_manager_simulation.py
@@ -5,8 +5,45 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from cosmpy.aerial.wallet import Wallet
+
 from allora_sdk.rpc_client.config import AlloraNetworkConfig
 from allora_sdk.rpc_client.tx_manager import FeeTier, TxError, TxManager
+
+
+class _StubWallet(Wallet):
+    """Minimal `Wallet` ABC subclass standing in for a custodial/remote signer."""
+
+    def __init__(self) -> None:
+        # Wallet exposes `data` as a read-only property, so UserString.__init__
+        # (which assigns self.data) must be bypassed.
+        pass
+
+    def address(self):
+        return "allo1stub"
+
+    def public_key(self):
+        return Mock()
+
+    def signer(self):
+        return Mock()
+
+
+def test_tx_manager_accepts_wallet_abc_subclass() -> None:
+    """An injected signer only satisfying the `Wallet` ABC must construct cleanly."""
+    wallet = _StubWallet()
+
+    manager = TxManager(
+        wallet=wallet,
+        tx_client=Mock(),
+        auth_client=Mock(),
+        bank_client=Mock(),
+        feemarket_client=Mock(),
+        config=AlloraNetworkConfig.testnet(),
+    )
+
+    assert manager.wallet is wallet
+    assert isinstance(manager.wallet, Wallet)
 
 
 def _make_manager() -> TxManager:


### PR DESCRIPTION
## Injectable `Wallet` seam — enables custodial/remote signing (e.g. Privy)

Part of the Forge → Hosting custody work: let a hosted worker sign chain
submissions via a **custodial/remote signer that never materializes the private
key** (Privy), instead of holding a raw mnemonic/private key locally.

### Why
Signing already flows entirely through cosmpy's abstract `Signer`/`Wallet`
interface (tx signing + the inference/reputer bundle `sign_digest`). The only
thing preventing a custom wallet is that the **worker** construction path
(`init_worker_wallet`) ignored an injected wallet and the config field was typed
concrete (`LocalWallet`). This widens the seam.

### Change (minimal, backward-compatible)
- `AlloraWalletConfig.wallet`: `Optional[LocalWallet]` → `Optional[Wallet]`
  (cosmpy's abstract base; `LocalWallet` is a subclass, so existing callers are
  unaffected).
- `init_worker_wallet()`: return `Wallet`, and **honor an injected `wallet.wallet`
  first** (before key/mnemonic/file). This is the one behavioral gap that blocked
  custom signers on the worker path.
- `AlloraRPCClient.wallet` type widened to `Wallet` (the client path already
  honored an injected wallet; this just fixes the annotation).

### Downstream
A `PrivyWallet(Wallet)` + `PrivySigner(Signer)` in worker-allora-sdk-v2 will be
injected here to sign via Privy `raw_sign` — see the design doc. Cosmos server
wallets + secp256k1 signing on Privy are confirmed feasible.

### Verification
- `py_compile` clean on all three changed files.
- `LocalWallet` confirmed to subclass cosmpy `Wallet` (existing callers unchanged).
- Full-import / runtime test needs the repo's proto codegen step (protos are
  generated, not committed), so it's exercised by the downstream PrivyWallet PR
  rather than a unit test here (the repo has no wallet-path tests today).

Note: touches `config.py`, which also appears in #84 (unrelated tx-robustness work) — different sections; expect a trivial or no conflict.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable injecting a `cosmpy` `Wallet` across the worker, RPC client, and tx flow to support custodial/remote signing (e.g., `Privy`) without materializing private keys. Backward-compatible with existing `LocalWallet` usage.

- **New Features**
  - `AlloraWalletConfig.wallet` now accepts any `cosmpy` `Wallet` and takes precedence over key/mnemonic; no fallback.
  - Worker wallet seam: `init_worker_wallet()` returns a `Wallet` and uses the injected `wallet.wallet` if provided; worker classes (`Forecaster`, `Inferer`, `Reputer`) now accept a `Wallet`.
  - `AlloraRPCClient.wallet` type widened to `Wallet`; debug log shows injected wallet type.
  - `TxManager` accepts a `Wallet` for signing; simulation test added to validate `Wallet` ABC subclass injection.

- **Bug Fixes**
  - Packaging: include generated `rpc_client` protobufs in wheel/sdist artifacts to prevent missing imports at runtime.

<sup>Written for commit 019bcd0fc24f11b45eeedb479f96840bc6d18950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

