### PR TITLE
Update CHANGELOG v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 # CHANGELOG
 
+## v1.2.0
+
+- New worker types (#37)
+    - `ReputerWorker` for submitting losses, with a configurable loss-methods subpackage (`absolute_error`, `squared_error`, `huber`, `log_cosh`, `poisson`, `binary_cross_entropy`, `ztae`, `zptae`)
+    - `ForecasterWorker` for submitting forecasts
+    - Auto-stake support for inferers, forecasters, and reputers
+    - Callback API reworked to use a `RunContext` and `reputer_fn`
+- Multi-value (multi-output) topic support, updated to `emissions.v10` protos (#71)
+- Worker event handling and gRPC reliability (#72)
+    - gRPC connection now auto-reconnects every 30 minutes to work around a GCP limitation
+    - Window opened/closed event handling reworked to avoid races
+- Loss function argument order changed (#77)
+- Fixed a float/decimal Go-vs-Python ser-de bug via decimal canonicalization (#62)
+- Gas estimation/simulation is now required for all transactions
+- Added staking RPC client and new emissions API endpoints
+- Removed `ml_workflow` and other unused dependencies (#73)
+- Follow-up hardening: tx concurrency/caching, sequence/nonce safety, autostake idempotence, reputer loss safety, and added simulation/loss tests (#45–#56)
+- Dependency bumps: `aiohttp` (#58), `pytest` (#60), `pygments` (#63), `requests` (#64), `protobuf` (#65)
+
 ## v1.1.0
 
 - `AlloraWorker`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `CHANGELOG.md` for v1.2.0: new workers, multi-output topics on `emissions.v10`, reliability hardening, staking APIs, and deps cleanup (removed `ml_workflow`; bumped `aiohttp`, `pytest`, `pygments`, `requests`, `protobuf`).

- **New Features**
  - New `ReputerWorker` and `ForecasterWorker`; auto-stake for inferers, forecasters, and reputers; configurable loss methods (`absolute_error`, `squared_error`, `huber`, `log_cosh`, `poisson`, `binary_cross_entropy`, `ztae`, `zptae`).
  - Multi-value topic support aligned to `emissions.v10`.
  - Callback API now uses `RunContext` and `reputer_fn`.
  - Staking RPC client and new emissions endpoints.

- **Bug Fixes**
  - gRPC auto-reconnect every 30 minutes; window event handling reworked to avoid races.
  - Decimal canonicalization fixes Go/Python float/decimal ser-de.
  - Gas estimation/simulation required for all transactions.
  - Hardening: tx concurrency/caching, sequence/nonce safety, autostake idempotence, reputer loss safety, adjusted loss arg order; plus simulation/loss tests.

<sup>Written for commit 569c59bc1249bb3ba67d77c31fe6d7d6daf8c90f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

