### PR TITLE
Make integration tests (API-based) not strictly required

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,9 +55,19 @@ jobs:
       - name: Generate RPC client code
         run:  make codegen
 
-      - name: Run tests
-        run:  uv run pytest tests
+      - name: Run unit tests
+        run: uv run pytest tests -m "not integration"
+
+      - name: Run integration tests (non-blocking)
+        id: integration
+        continue-on-error: true
+        run: uv run pytest tests -m integration -v
         env:
           ALLORA_API_KEY: ${{ secrets.ALLORA_API_KEY }}
+
+      - name: Warn on integration test failures
+        if: steps.integration.outcome == 'failure'
+        run: |
+          echo "::warning::Integration tests failed. Deployment is not blocked; check live API availability at https://api.allora.network/v2"
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,10 @@ jobs:
       # gray/neutral (non-blocking) when they fail. Skipped on forked PRs, whose
       # read-only GITHUB_TOKEN cannot create checks.
       - name: Publish integration status check
+        # Best-effort: a failure to post the check must not fail this
+        # non-blocking job. The API error stays visible in the step log.
         if: ${{ always() && github.event.pull_request.head.repo.fork != true }}
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,16 +58,69 @@ jobs:
       - name: Run unit tests
         run: uv run pytest tests -m "not integration"
 
-      - name: Run integration tests (non-blocking)
+  integration:
+    name: integration tests (non-blocking)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate RPC client code
+        run: make codegen
+
+      - name: Run integration tests
         id: integration
         continue-on-error: true
         run: uv run pytest tests -m integration -v
         env:
           ALLORA_API_KEY: ${{ secrets.ALLORA_API_KEY }}
 
-      - name: Warn on integration test failures
-        if: steps.integration.outcome == 'failure'
-        run: |
-          echo "::warning::Integration tests failed. Deployment is not blocked; check live API availability at https://api.allora.network/v2"
+      # Report integration results as a separate check: green when they pass,
+      # gray/neutral (non-blocking) when they fail. Skipped on forked PRs, whose
+      # read-only GITHUB_TOKEN cannot create checks.
+      - name: Publish integration status check
+        if: ${{ always() && github.event.pull_request.head.repo.fork != true }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const outcome = '${{ steps.integration.outcome }}';
+            const conclusion = outcome === 'success' ? 'success' : 'neutral';
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'integration-tests',
+              head_sha: sha,
+              status: 'completed',
+              conclusion,
+              output: {
+                title: outcome === 'success'
+                  ? 'Integration tests passed'
+                  : 'Integration tests failed (non-blocking)',
+                summary: outcome === 'success'
+                  ? 'Live-network integration tests passed.'
+                  : 'Live-network integration tests failed. Merge/deploy is not blocked; check live API availability at https://api.allora.network/v2',
+              },
+            });
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,10 @@ commands = [["mypy", { replace = "posargs", default = ["src", "tests"], extend =
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-markers = ["asyncio: mark test as async test"]
+markers = [
+    "asyncio: mark test as async test",
+    "integration: live-network smoke tests (optional in CI)",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/test_api_client_integration.py
+++ b/tests/test_api_client_integration.py
@@ -10,6 +10,8 @@ from allora_sdk.api_client import (
 
 DEFAULT_TEST_TIMEOUT = 30  # 30 seconds
 
+pytestmark = pytest.mark.integration
+
 requires_api_key = pytest.mark.skipif(
     not os.getenv("ALLORA_API_KEY"),
     reason="ALLORA_API_KEY environment variable not set",


### PR DESCRIPTION
## Separate integration tests from unit tests in CI

### Problem
CI ran the entire suite with a single `uv run pytest tests` step. The live-network integration tests (`tests/test_api_client_integration.py`) hit the Allora API, so whenever the API was unavailable the whole `test` job went red and **blocked deployment** — even though the unit tests (fully mocked) passed.

### Change
Split the test run into two steps and register an `integration` pytest marker:

- **Unit tests — blocking:** `uv run pytest tests -m "not integration"`. Must pass; these are deterministic and mock-based.
- **Integration tests — non-blocking:** `uv run pytest tests -m integration -v` with `continue-on-error: true`. They still run, but a failure no longer fails the job. `ALLORA_API_KEY` is now scoped to this step only.
- **Warning on failure:** emits a `::warning::` annotation when the integration step fails, so live-API breakage is still surfaced without blocking merges/deploys.

### Files
- `.github/workflows/test.yaml` — the two-step split + warning step
- `pyproject.toml` — registers the `integration` marker
- `tests/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split CI tests into blocking unit tests and non-blocking integration tests to prevent deploys from being blocked by external API outages. Integration failures now publish a neutral status check instead of failing the job.

- **Refactors**
  - Added `integration` `pytest` marker and applied via file-level `pytestmark` to live-network tests.
  - Updated GitHub Actions: unit job runs `uv run pytest -m "not integration"`; integration runs in a separate job with `continue-on-error: true` and `ALLORA_API_KEY` scoped to that job.
  - Published an `integration-tests` check via `actions/github-script`: green on pass, gray/neutral on fail; uses PR head SHA, requires `checks: write` permission, skips on forked PRs, and publishing errors do not fail the job.

<sup>Written for commit 1210544ddff750106d359cc055e51889f307cd55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

