### PR TITLE
Hardcode integration test to use topic 13

### DIFF
--- a/tests/test_api_client_integration.py
+++ b/tests/test_api_client_integration.py
@@ -50,11 +50,8 @@ async def test_get_all_topics(client):
 @requires_api_key
 @pytest.mark.asyncio
 async def test_get_inference_by_topic_id(client):
-    topics = await client.get_all_topics()
-    if not topics:
-        pytest.skip("No topics available for testing")
-
-    inference = await client.get_inference_by_topic_id(topics[0].topic_id)
+    # Hardcoding topic 13 as it's one of the most reliable topics
+    inference = await client.get_inference_by_topic_id(13)
 
     assert isinstance(inference, Inference)
     assert isinstance(inference.signature, str)
@@ -81,4 +78,3 @@ async def test_get_price_inference_different_assets(client):
         assert isinstance(inference, Inference)
         assert inference.inference_data.network_inference.isdigit()
         assert float(inference.inference_data.network_inference_normalized) > 0
-


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardcodes the integration test to call get_inference_by_topic_id with topic ID 13, removing the dependency on fetching topics and preventing flaky skips when no topics are returned.

<sup>Written for commit d9e7a71e1e2358450085ce0d63b645b1a06174af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

