### PR TITLE
Use GetOpenReputerSubmissionWindows query for reputers

### DIFF
--- a/src/allora_sdk/worker/reputer.py
+++ b/src/allora_sdk/worker/reputer.py
@@ -10,9 +10,9 @@ from allora_sdk.rpc_client.protos.emissions.v10 import (
     CanSubmitReputerPayloadRequest,
     EventReputerSubmissionWindowOpened,
     GetNetworkInferencesAtBlockRequest,
+    GetOpenReputerSubmissionWindowsRequest,
     GetStakeFromReputerInTopicInSelfRequest,
     GetTopicRequest,
-    GetUnfulfilledReputerNoncesRequest,
     IsReputerRegisteredInTopicIdRequest,
     NetworkInferenceBundle,
     LabeledValue,
@@ -118,12 +118,14 @@ class Reputer:
 
 
     async def get_unfulfilled_nonces(self) -> set[int]:
-
         # GetUnfulfilledReputerNonces gives all epochs in flight, which is not what we want here
-        # GetOpenReputerSubmissionWindows would be the more appropriate RPC call, but
-        # it doesn't seem to be implemented in the rpc client
-        # Returning [] here means we only react to EventReputerSubmissionWindowOpened
-        return set()
+        # So we use GetOpenReputerSubmissionWindows instead
+        resp = await self.client.emissions.query.get_open_reputer_submission_windows(
+            GetOpenReputerSubmissionWindowsRequest(topic_id=self.topic_id)
+        )
+        if resp.nonces is None:
+            return set[int]()
+        return {x.reputer_nonce.block_height for x in resp.nonces.nonces}
 
 
     async def submit(self, nonce: int, account_seq: int) -> WorkerResult[InputValueBundle] | TxError | Exception:

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -745,7 +745,11 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
             self.stop()
             return
 
-        nonces = await self.use_case.get_unfulfilled_nonces()
+        # catch errors so that `nonce` is still processed if query fails
+        try:
+            nonces = await self.use_case.get_unfulfilled_nonces()
+        except Exception as err:
+            nonces = set()
         new_nonces = { n for n in nonces if n not in self.submitted_nonces }
 
         if nonce is not None and nonce not in self.submitted_nonces:

--- a/src/allora_sdk/worker/worker.py
+++ b/src/allora_sdk/worker/worker.py
@@ -749,6 +749,7 @@ class AlloraWorker(Generic[SubmissionWindowOpenEventType, WorkerFnReturnType]):
         try:
             nonces = await self.use_case.get_unfulfilled_nonces()
         except Exception as err:
+            logger.warning(f"   Failed querying unfulfilled nonces for topic {self.topic_id}: {err}")
             nonces = set()
         new_nonces = { n for n in nonces if n not in self.submitted_nonces }
 

--- a/tests/test_reputer_submit.py
+++ b/tests/test_reputer_submit.py
@@ -97,9 +97,9 @@ async def test_submit_returns_error_when_network_inferences_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_unfulfilled_nonces_uses_reputer_request_nonces() -> None:
+async def test_get_unfulfilled_nonces_uses_open_submission_windows() -> None:
     client = _make_client()
-    client.emissions.query.get_unfulfilled_reputer_nonces = AsyncMock(
+    client.emissions.query.get_open_reputer_submission_windows = AsyncMock(
         return_value=Mock(
             nonces=Mock(
                 nonces=[
@@ -108,6 +108,18 @@ async def test_get_unfulfilled_nonces_uses_reputer_request_nonces() -> None:
                 ]
             )
         )
+    )
+
+    reputer = _make_reputer(client)
+
+    assert await reputer.get_unfulfilled_nonces() == {101, 202}
+
+
+@pytest.mark.asyncio
+async def test_get_unfulfilled_nonces_empty_when_no_windows_open() -> None:
+    client = _make_client()
+    client.emissions.query.get_open_reputer_submission_windows = AsyncMock(
+        return_value=Mock(nonces=None)
     )
 
     reputer = _make_reputer(client)


### PR DESCRIPTION
We had effectively disabled polling for reputers because the `GetUnfulfilledNonces` call returned too many nonces (it included epochs not ready for reputation yet). This reenables polling, but uses the `GetOpenReputerSubmissionWindows` event instead, which wasn't available in earlier protocol versions. Should result in a slight improvement of reputer reliability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables reputer polling by querying open submission windows and handles query failures without blocking submissions. Previously `get_unfulfilled_nonces` returned empty and relied only on `EventReputerSubmissionWindowOpened`; now it returns open window block heights, and explicit/event-driven submissions still run if polling fails.

- Implement `get_unfulfilled_nonces` via `emissions.query.get_open_reputer_submission_windows(...)`; returns empty when no windows or `nonces` is `None`.
- Catch exceptions in `_maybe_submit_impl`, log a warning on failure, and continue processing the provided `nonce`.
- Compatibility: nodes must expose `GetOpenReputerSubmissionWindows` for polling; on older protocol versions, only event-driven submissions will run.

<sup>Written for commit 58009627f7549287f9cd3246e2c9207213ca4cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

