### PR TITLE
fix: make the wheel target depend on codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,11 @@ install_as_editable:
 .PHONY: codegen
 codegen: $(PROTO_STAMP) $(INTERFACE_STAMP) $(REST_STAMP) $(GRPC_STAMP)
 
+# The rpc_client protos/rest/grpc/interfaces packages are generated and
+# gitignored, so building from a clean checkout produces a wheel that installs
+# but cannot be imported. Depend on codegen so that is impossible.
 .PHONY: wheel
-wheel:
+wheel: codegen
 	uv build
 
 # --- Git dependencies

--- a/README.md
+++ b/README.md
@@ -459,8 +459,10 @@ make dev
 # Run tests
 tox
 
-# Build wheel for distribution
-make wheel      # or: uv build
+# Build wheel for distribution. Use make wheel, not a bare `uv build`: the
+# generated packages are gitignored, and uv build will happily produce a wheel
+# without them that installs but fails on import.
+make wheel
 ```
 
 ### Dependencies


### PR DESCRIPTION
## Problem

`make wheel` was a bare `uv build`. Four packages under `src/allora_sdk/rpc_client/` — `protos/`, `rest/`, `grpc/`, `interfaces/` — are produced by codegen and gitignored (`.gitignore:18-21`), so nothing under them is tracked in git.

From a clean checkout, `uv build` therefore succeeds and produces a wheel with none of them in it. The result installs fine and fails on the first import:

```
ModuleNotFoundError: No module named 'allora_sdk.rpc_client.protos'
  allora_sdk/rpc_client/client.py:25
```

The failure is silent at build time and only visible to whoever installs the artifact. It is also easy to miss locally, because a working tree that has ever run `make dev` already has the generated packages sitting in it — the wheel comes out correct there and broken anywhere else.

## Fix

Make the `wheel` target depend on `codegen`. The codegen targets are stamp-driven, so this is a no-op on a tree that has already generated (the common case) and generates on a clean one. If the codegen tools are not installed, `make` fails on the stamp rule and never reaches `uv build` — a loud failure instead of a broken artifact. Bootstrapping those tools is still `make dev`, unchanged.

Also dropped the `# or: uv build` suggestion from the README's build step, since that is precisely the path that produces the broken wheel.

## Verification

Built from this branch's base commit, both ways:

| Build | Wheel size | `rpc_client/protos` entries | `import allora_sdk` |
|---|---|---|---|
| `uv build` on a clean checkout | 103 KB | 0 | ModuleNotFoundError |
| `make dev && make wheel` | 541 KB | 180 | OK |

The passing wheel was installed into a fresh venv and imported; `TxManager` exposes `fee_granter`, `max_fees`, `gas_adjustment`, `base_gas` and `simulate_gas_from_start`, and `AlloraNetworkConfig` no longer carries the removed second gas multiplier.

No change to package contents, dependencies, or published metadata — only to how the artifact is built.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents broken wheels from clean checkouts by making `make wheel` depend on codegen. Previously `make wheel` (a bare `uv build`) omitted generated `allora_sdk.rpc_client.{protos,rest,grpc,interfaces}` and produced installable-but-broken artifacts; now we generate them first or fail early.

- Build: `wheel` depends on `codegen` (stamp-driven; no-op if already generated).
- Failure mode: if codegen tools are missing, `make wheel` fails before `uv build` instead of emitting a bad wheel.
- Docs: README now instructs to use `make wheel` only; bare `uv build` is not supported for distribution.
- Action: run `make dev` to bootstrap codegen tools if needed.
- No changes to package contents, dependencies, or published metadata.

<sup>Written for commit 36cf2d53f1bc39b74fd7f1bc4c883cf1b80946fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-sdk-py/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

